### PR TITLE
Require Python 3 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='pyaoscx',
       author='Aruba Switching Automation',
       author_email='aruba-switching-automation@hpe.com',
       license='Apache 2.0',
+      python_requires='>=3',
     classifiers=[
 
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
According to the PyPI trove classifiers, this project only runs on Python 3. However, it is still installable in a Python 2 environment.

Using the [`python_requires` argument to `setup.py`](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires) will prevent this package from being erroneously installed in Python 2 environments (for environments that have relatively recent releases of setuptools), like the [CircleCI config](https://github.com/StackStorm-Exchange/exchange-incubator/blob/master/.circleci/config.yml#L6), which caused the CI failure for StackStorm-Exchange/exchange-incubator#154:

```
Collecting pyaoscx (from -r /home/circleci/repo/requirements.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/27/df/5642ea07a28c6699db2bedafb1526fe96f23b669638ad56812c7eb797195/pyaoscx-0.2.0.tar.gz (53kB)
    100% |████████████████████████████████| 61kB 8.8MB/s eta 0:00:01
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-HboRg_/pyaoscx/setup.py", line 6, in <module>
        with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
    TypeError: 'encoding' is an invalid keyword argument for this function
    
```

I will also propose a PR to [exchange-incubator](https://github.com/StackStorm-Exchange/exchange-incubator) to use the Python 3 image in CircleCI, which should fix that issue for future PRs to that project. However, this PR is orthogonal to that change, and is still useful and necessary in other contexts.