### PR TITLE
Workaround to make mac.get() fetch Interfaces

### DIFF
--- a/pyaoscx/pyaoscx_module.py
+++ b/pyaoscx/pyaoscx_module.py
@@ -205,6 +205,9 @@ class PyaoscxModule(ABC):
             )
 
         payload = {"depth": depth, "selector": selector}
+        if "macs" in self.path:
+            self.path = self.path.lower()
+            payload = {"depth": None, "selector": None}
 
         try:
             response = self.session.request("GET", self.path, params=payload)


### PR DESCRIPTION
set the path to lowercase, calling:

`system/vlans/1/macs/dynamic,00%3Aaa%3Abb%3Acc%3A00%3A11` works while
`system/vlans/1/macs/dynamic,00%3AAA%3ABB%3ACC%3ADD%3AEE` does not.

payload change:
- setting _either_ depth or selector to None was enough to get it
working. Having either set to None resulted in the GET call being
without depth and selector in the URI.

```
DEBUG:urllib3.connectionpool:https://cx6100.example.org:443 "GET /rest/v10.08/system/vlans/1/macs/dynamic,00%3Aaa%3Abb%3Acc%3A00%3A11 HTTP/1.1" 200 362
```

I am new to this code so unable to right now judge how bad this impacts
 other calls.

https://github.com/aruba/pyaoscx/blob/master/RELEASE-NOTES.md#notable-changes-2
has a bit about MAC module being supported after the recent architecture
changes in pyaoscx.

I have ran a `pip3 uninstall pyaoscx` and then `python setup.py install` to install this branch.

Related to GitHub Issue #18