### PR TITLE
Fixed poe check

### DIFF
--- a/pyaoscx/poe_interface.py
+++ b/pyaoscx/poe_interface.py
@@ -62,7 +62,7 @@ class PoEInterface(Interface):
         :return: Returns True if no exception is raised.
         """
         device = Device(self.session)
-        if device.is_capable("quick_poe"):
+        if device.is_capable("poe"):
             raise UnsupportedCapabilityError("This device is not PoE capable.")
 
         logging.info("Retrieving %s from switch", self)


### PR DESCRIPTION
The previous version was checking if the switch supported poe by using the setting `quick_poe`. This should be `poe`. This PR fix changes the check from `quick_poe` to `poe`. 