### PR TITLE
interface(loopback): add check for same ipv4_address_secondary

### DIFF
--- a/pyaoscx/interface.py
+++ b/pyaoscx/interface.py
@@ -1328,7 +1328,9 @@ class Interface(PyaoscxModule):
                 if i == 0:
                     self.ip4_address = ipv4[i]
                 else:
-                    self.ip4_address_secondary.append(ipv4[i])
+                    #Check if there is already the same ip4_address_secondary configured
+                    if ipv4[i] not in self.ip4_address_secondary:
+                        self.ip4_address_secondary.append(ipv4[i])
         # If IPv4 is empty, delete
         elif ipv4 == []:
             self.ip4_address = None
@@ -1338,7 +1340,6 @@ class Interface(PyaoscxModule):
             self.description = description
 
         # Set all remaining attributes to create a loopback
-
         # when configuring a loopback interface, it must be powered on
         self.admin_state = "up"
 


### PR DESCRIPTION
When using the following code and repeat twice, the second time (like for ansible with idempotent) you get an 500 error 

`Ran into exception: 'GENERIC OPERATION ERROR: Internal service error.\n: Code: 500'. Closing session.`


```python
import urllib3
from pyaoscx.session import Session
from pyaoscx.pyaoscx_factory import PyaoscxFactory
from pyaoscx.vlan import Vlan
from pyaoscx.interface import Interface
from pyaoscx.device import Device

version = "10.09"
switch_ip = "10.200.11.147"

urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
s = Session(switch_ip, version)
s.open("admin", "MyPassword")

try:
    device = Device(s)
    
    ipv4 = ["10.23.23.1/24", "10.123.23.1/24"]

    #print("ipv4 {0}".format(ipv4))
    loopback_interface = device.interface("loopback23")
    loopback_interface.configure_loopback(
                ipv4=ipv4,
                vrf = None
    )
except Exception as error:
    print("Ran into exception: {0}. Closing session.".format(error))

finally:
    s.close()
```

add simple check for don't append with same ip the ipv4_secondary attribut

