### PR TITLE
interface: add depth parameter to get_facts

### DIFF
--- a/pyaoscx/interface.py
+++ b/pyaoscx/interface.py
@@ -402,7 +402,7 @@ class Interface(PyaoscxModule):
         return name, interface_obj
 
     @classmethod
-    def get_facts(cls, session):
+    def get_facts(cls, session, depth=None):
         """
         Perform a GET call to retrieve all Interfaces and their data.
 
@@ -415,7 +415,11 @@ class Interface(PyaoscxModule):
         logging.info("Retrieving the switch interfaces facts")
 
         # Set depth
-        interface_depth = session.api.default_facts_depth
+        interface_depth = depth or session.api.default_facts_depth
+
+        if not session.api.valid_depth(interface_depth):
+            interface_depth = session.api.default_facts_depth
+            raise Exception("ERROR: Depth should be {0}".format(interface_depth))
 
         # Build URI
         uri = "{0}?depth={1}".format(Interface.base_uri, interface_depth)


### PR DESCRIPTION
sometimes like for check if an interface exist, you need only to get depth with length 1

avoid to get all data (more speed and efficentiy )

example with Aruba-CX OVA :

with depth=1
"GET /rest/v10.09/system/interfaces?depth=1 HTTP/1.1" "/rest/v10.09/system/interfaces?depth=1" 200 3068 "-" "python-requests/2.28.1"

with depth=2
"GET /rest/v10.09/system/interfaces?depth=2 HTTP/1.1" "/rest/v10.09/system/interfaces?depth=2" 200 1256622 "-" "python-requests/2.28.1" -

3Kb vs 1.19Mb !