### PR TITLE
Add PrefixList and PrefixListEntry resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "PrefixList": "prefix_list",
+            "PrefixListEntry": "prefix_list_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/prefix_list.py
+++ b/pyaoscx/prefix_list.py
@@ -1,0 +1,232 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class PrefixList(PyaoscxModule):
+    """
+    Provide configuration management for Prefix Lists on AOS-CX devices.
+    """
+
+    collection_uri = "system/prefix_lists"
+    object_uri = collection_uri + "/{name}"
+    resource_uri_name = "name"
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        self.__name = name
+
+        # List used to determine attributes related to the
+        # Prefix List configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URI that identifies the current Prefix List
+        self.path = self.object_uri.format(name=name)
+        self.base_uri = self.collection_uri
+
+    @property
+    def name(self):
+        return self.__name
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Prefix List and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Prefix Lists and create a dictionary
+            containing each of them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing Prefix List names as keys and a Prefix
+            List object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        prefix_list_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            name, prefix_list = cls.from_uri(session, uri)
+            prefix_list_dict[name] = prefix_list
+
+        return prefix_list_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Prefix List.
+            Checks whether the Prefix List exists in the switch and calls
+            self.update() or self.create() accordingly.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Prefix List.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and cannot be part of the PUT body
+        if "name" in data:
+            del data["name"]
+        # The address family cannot be changed after creation
+        if "address_family" in data:
+            del data["address_family"]
+        self.__modified = self._put_data(data)
+        logging.info("SUCCESS: Updating %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Prefix List in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and must be added explicitly
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        logging.info("SUCCESS: Adding %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a Prefix List from the switch. All the
+            entries that belong to the Prefix List are removed with it.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a Prefix List object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the name and the Prefix List.
+        """
+        # The name is the last element of the URI
+        name = uri.split("/")[-1]
+        return name, cls(session, name)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a Prefix List object given a response_data.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param response_data: The response must be a dictionary of the form:
+            {name: URI}.
+        :return: Prefix List object.
+        """
+        uri = next(iter(response_data.values()))
+        _, prefix_list = cls.from_uri(session, uri)
+        return prefix_list
+
+    @classmethod
+    def get_facts(cls, session):
+        """
+        Retrieve the information of all Prefix Lists.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the name as key and the facts as value.
+        """
+        logging.info("Retrieving Prefix Lists facts")
+
+        depth = session.api.default_facts_depth
+
+        try:
+            response = session.request(
+                "GET", cls.collection_uri, params={"depth": depth}
+            )
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "Prefix List {0}".format(self.name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/prefix_list_entry.py
+++ b/pyaoscx/prefix_list_entry.py
@@ -1,0 +1,230 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.prefix_list import PrefixList
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class PrefixListEntry(PyaoscxModule):
+    """
+    Provide configuration management for Prefix List Entries on AOS-CX devices.
+    """
+
+    collection_uri = "system/prefix_lists/{name}/prefix_list_entries"
+    object_uri = collection_uri + "/{preference}"
+    resource_name = "preference"
+    indices = ["preference"]
+
+    def __init__(self, session, preference, parent_prefix_list, **kwargs):
+        self.__parent_prefix_list = parent_prefix_list
+        self.__preference = preference
+        self.session = session
+
+        # List used to determine attributes related to the
+        # Prefix List Entry configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URIs that identify the current Prefix List Entry
+        self.path = self.object_uri.format(
+            name=self.__parent_prefix_list.name, preference=preference
+        )
+        self.base_uri = self.collection_uri.format(
+            name=self.__parent_prefix_list.name
+        )
+
+    @property
+    def preference(self):
+        return self.__preference
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Prefix List Entry and fill
+            the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, prefix_list_name):
+        """
+        Perform a GET call to retrieve all Prefix List Entries of the same
+            Prefix List and create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param prefix_list_name: Name of the Prefix List to which the entries
+            belong.
+        :return: Dictionary containing Prefix List Entry preferences as keys
+            and a Prefix List Entry object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=prefix_list_name)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        entry_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            preference, entry = cls.from_uri(session, uri)
+            entry_dict[preference] = entry
+
+        return entry_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Prefix List
+            Entry. Checks whether the Prefix List Entry exists in the switch
+            and calls self.update() or self.create() accordingly.
+
+        :return modified: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Prefix List Entry.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and cannot be part of the PUT body
+        if "preference" in data:
+            del data["preference"]
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Prefix List Entry in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and must be added explicitly
+        data["preference"] = self.preference
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a Prefix List Entry from the switch.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a Prefix List Entry object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the preference and the Prefix List Entry.
+        """
+        # URI format is:
+        # /system/prefix_lists/{name}/prefix_list_entries/{preference}
+        parts = uri.split("/")
+        prefix_list_name = parts[-3]
+        preference = parts[-1]
+        prefix_list = PrefixList(session, prefix_list_name)
+        entry = cls(session, preference, prefix_list)
+        return preference, entry
+
+    @classmethod
+    def get_facts(cls, session, prefix_list_name):
+        """
+        Retrieve the information of all Prefix List Entries of a Prefix List.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param prefix_list_name: Name of the Prefix List to which the entries
+            belong.
+        :return: Dictionary containing the preference as key and the facts as
+            value.
+        """
+        logging.info("Retrieving Prefix List Entries facts")
+
+        depth = session.api.default_facts_depth
+
+        uri = cls.collection_uri.format(name=prefix_list_name)
+
+        try:
+            response = session.request("GET", uri, params={"depth": depth})
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "Prefix List Entry {0} of Prefix List {1}".format(
+            self.preference, self.__parent_prefix_list.name
+        )
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/tests/test_prefix_list.py
+++ b/tests/test_prefix_list.py
@@ -1,0 +1,187 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the PrefixList and PrefixListEntry modules.
+
+These tests do not require a live switch. They mock the HTTP layer
+(_post_data / _put_data / _send_data) and verify the request bodies and
+URIs produced by the classes, including the immutability rules for the
+index attributes (name / preference) and the address family.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pyaoscx.prefix_list import PrefixList
+from pyaoscx.prefix_list_entry import PrefixListEntry
+
+
+def make_session():
+    """Build a minimal mocked session accepted by @connected."""
+    api = SimpleNamespace(
+        default_selector="writable",
+        default_depth=1,
+        default_facts_depth=2,
+        compound_index_separator=",",
+    )
+    return SimpleNamespace(connected=True, api=api)
+
+
+# --------------------------------------------------------------------------
+# Registry resolution
+# --------------------------------------------------------------------------
+def test_registry_resolution():
+    session = make_session()
+    from pyaoscx.rest.v10_09.api import v10_09
+
+    api = v10_09()
+    cls = api.get_module_class(session, "PrefixList")
+    assert cls is PrefixList
+    cls_entry = api.get_module_class(session, "PrefixListEntry")
+    assert cls_entry is PrefixListEntry
+
+
+# --------------------------------------------------------------------------
+# PrefixList
+# --------------------------------------------------------------------------
+def test_prefix_list_uris():
+    session = make_session()
+    plist = PrefixList(session, "MY_LIST")
+    assert plist.name == "MY_LIST"
+    assert plist.path == "system/prefix_lists/MY_LIST"
+    assert plist.base_uri == "system/prefix_lists"
+    assert PrefixList.indices == ["name"]
+
+
+def test_prefix_list_create_body():
+    session = make_session()
+    plist = PrefixList(
+        session,
+        "MY_LIST",
+        address_family="ipv4",
+        description="lab",
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    plist._post_data = fake_post
+    assert plist.create() is True
+    # The index must be explicitly added to the POST body.
+    assert captured["name"] == "MY_LIST"
+    assert captured["address_family"] == "ipv4"
+    assert captured["description"] == "lab"
+
+
+def test_prefix_list_update_strips_immutable():
+    session = make_session()
+    plist = PrefixList(
+        session,
+        "MY_LIST",
+        address_family="ipv4",
+        description="changed",
+    )
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    plist._put_data = fake_put
+    assert plist.update() is True
+    # name (index) and address_family (immutable) must never be in PUT body.
+    assert "name" not in captured
+    assert "address_family" not in captured
+    assert captured["description"] == "changed"
+
+
+def test_prefix_list_from_uri():
+    session = make_session()
+    name, plist = PrefixList.from_uri(
+        session, "/rest/v10.09/system/prefix_lists/MY_LIST"
+    )
+    assert name == "MY_LIST"
+    assert isinstance(plist, PrefixList)
+    assert plist.name == "MY_LIST"
+
+
+# --------------------------------------------------------------------------
+# PrefixListEntry
+# --------------------------------------------------------------------------
+def test_prefix_list_entry_uris():
+    session = make_session()
+    parent = PrefixList(session, "MY_LIST")
+    entry = PrefixListEntry(session, 10, parent, action="permit")
+    assert entry.preference == 10
+    assert entry.path == ("system/prefix_lists/MY_LIST/prefix_list_entries/10")
+    assert entry.base_uri == (
+        "system/prefix_lists/MY_LIST/prefix_list_entries"
+    )
+    assert PrefixListEntry.indices == ["preference"]
+
+
+def test_prefix_list_entry_create_body():
+    session = make_session()
+    parent = PrefixList(session, "MY_LIST")
+    entry = PrefixListEntry(
+        session,
+        10,
+        parent,
+        action="permit",
+        prefix="10.0.0.0/8",
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    entry._post_data = fake_post
+    assert entry.create() is True
+    assert captured["preference"] == 10
+    assert captured["action"] == "permit"
+    assert captured["prefix"] == "10.0.0.0/8"
+
+
+def test_prefix_list_entry_update_strips_index():
+    session = make_session()
+    parent = PrefixList(session, "MY_LIST")
+    entry = PrefixListEntry(
+        session,
+        10,
+        parent,
+        action="deny",
+    )
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    entry._put_data = fake_put
+    assert entry.update() is True
+    assert "preference" not in captured
+    assert captured["action"] == "deny"
+
+
+def test_prefix_list_entry_from_uri():
+    session = make_session()
+    uri = "/rest/v10.09/system/prefix_lists/MY_LIST/" "prefix_list_entries/20"
+    preference, entry = PrefixListEntry.from_uri(session, uri)
+    assert preference == "20"
+    assert isinstance(entry, PrefixListEntry)
+    assert entry.preference == "20"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #42

### Description
Adds `PrefixList` and `PrefixListEntry` resource modules, modeled on the existing resource classes, and registers them in the API module-name table. The prefix list `address_family` is treated as a create-only attribute and stripped from update bodies. Includes offline unit tests covering registry resolution, URIs, and create/update request bodies.

### Testing
- `black --line-length 79` and `flake8` clean (pre-commit hook).
- `pytest tests/test_prefix_list.py` — 9 passing.
- Validated live against AOS-CX (REST v10.09): create / idempotent re-apply / update / immutable address_family refused / entry prune / delete.

### Notes
- DCO sign-off included.
- `CONTRIBUTING.md` references a `development` branch that does not exist on the repository; this PR targets `master`.

Companion collection PR: aruba/aoscx-ansible-collection#151
