### PR TITLE
Add RouteMap and RouteMapEntry resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "RouteMap": "route_map",
+            "RouteMapEntry": "route_map_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/route_map.py
+++ b/pyaoscx/route_map.py
@@ -1,0 +1,229 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RouteMap(PyaoscxModule):
+    """
+    Provide configuration management for Route Maps on AOS-CX devices.
+    """
+
+    collection_uri = "system/route_maps"
+    object_uri = collection_uri + "/{name}"
+    resource_uri_name = "name"
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        self.__name = name
+
+        # List used to determine attributes related to the
+        # Route Map configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URI that identifies the current Route Map
+        self.path = self.object_uri.format(name=name)
+        self.base_uri = self.collection_uri
+
+    @property
+    def name(self):
+        return self.__name
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Route Map and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Route Maps and create a dictionary
+            containing each of them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing Route Map names as keys and a Route Map
+            object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        route_map_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            name, route_map = cls.from_uri(session, uri)
+            route_map_dict[name] = route_map
+
+        return route_map_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Route Map.
+            Checks whether the Route Map exists in the switch and calls
+            self.update() or self.create() accordingly.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Route Map.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and cannot be part of the PUT body
+        if "name" in data:
+            del data["name"]
+        self.__modified = self._put_data(data)
+        logging.info("SUCCESS: Updating %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Route Map in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and must be added explicitly
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        logging.info("SUCCESS: Adding %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a Route Map from the switch. All the
+            entries that belong to the Route Map are removed with it.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a Route Map object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the name and the Route Map.
+        """
+        # The name is the last element of the URI
+        name = uri.split("/")[-1]
+        return name, cls(session, name)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a Route Map object given a response_data.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param response_data: The response must be a dictionary of the form:
+            {name: URI}.
+        :return: Route Map object.
+        """
+        uri = next(iter(response_data.values()))
+        _, route_map = cls.from_uri(session, uri)
+        return route_map
+
+    @classmethod
+    def get_facts(cls, session):
+        """
+        Retrieve the information of all Route Maps.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the name as key and the facts as value.
+        """
+        logging.info("Retrieving Route Maps facts")
+
+        depth = session.api.default_facts_depth
+
+        try:
+            response = session.request(
+                "GET", cls.collection_uri, params={"depth": depth}
+            )
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "Route Map {0}".format(self.name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/route_map_entry.py
+++ b/pyaoscx/route_map_entry.py
@@ -1,0 +1,230 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.route_map import RouteMap
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RouteMapEntry(PyaoscxModule):
+    """
+    Provide configuration management for Route Map Entries on AOS-CX devices.
+    """
+
+    collection_uri = "system/route_maps/{name}/route_map_entries"
+    object_uri = collection_uri + "/{preference}"
+    resource_name = "preference"
+    indices = ["preference"]
+
+    def __init__(self, session, preference, parent_route_map, **kwargs):
+        self.__parent_route_map = parent_route_map
+        self.__preference = preference
+        self.session = session
+
+        # List used to determine attributes related to the
+        # Route Map Entry configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URIs that identify the current Route Map Entry
+        self.path = self.object_uri.format(
+            name=self.__parent_route_map.name, preference=preference
+        )
+        self.base_uri = self.collection_uri.format(
+            name=self.__parent_route_map.name
+        )
+
+    @property
+    def preference(self):
+        return self.__preference
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Route Map Entry and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, route_map_name):
+        """
+        Perform a GET call to retrieve all Route Map Entries of the same Route
+            Map and create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param route_map_name: Name of the Route Map to which the entries
+            belong.
+        :return: Dictionary containing Route Map Entry preferences as keys and
+            a Route Map Entry object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=route_map_name)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        entry_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            preference, entry = cls.from_uri(session, uri)
+            entry_dict[preference] = entry
+
+        return entry_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Route Map
+            Entry. Checks whether the Route Map Entry exists in the switch and
+            calls self.update() or self.create() accordingly.
+
+        :return modified: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Route Map Entry.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and cannot be part of the PUT body
+        if "preference" in data:
+            del data["preference"]
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Route Map Entry in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and must be added explicitly
+        data["preference"] = self.preference
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a Route Map Entry from the switch.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a Route Map Entry object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the preference and the Route Map Entry.
+        """
+        # URI format is:
+        # /system/route_maps/{name}/route_map_entries/{preference}
+        parts = uri.split("/")
+        route_map_name = parts[-3]
+        preference = parts[-1]
+        route_map = RouteMap(session, route_map_name)
+        entry = cls(session, preference, route_map)
+        return preference, entry
+
+    @classmethod
+    def get_facts(cls, session, route_map_name):
+        """
+        Retrieve the information of all Route Map Entries of a Route Map.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param route_map_name: Name of the Route Map to which the entries
+            belong.
+        :return: Dictionary containing the preference as key and the facts as
+            value.
+        """
+        logging.info("Retrieving Route Map Entries facts")
+
+        depth = session.api.default_facts_depth
+
+        uri = cls.collection_uri.format(name=route_map_name)
+
+        try:
+            response = session.request("GET", uri, params={"depth": depth})
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "Route Map Entry {0} of Route Map {1}".format(
+            self.preference, self.__parent_route_map.name
+        )
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/tests/test_route_map.py
+++ b/tests/test_route_map.py
@@ -1,0 +1,144 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the RouteMap and RouteMapEntry modules.
+
+These tests do not require a live switch. They mock the HTTP layer
+(_post_data / _put_data) and verify the request bodies and URIs produced by
+the classes, including the index immutability rules.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pyaoscx.route_map import RouteMap
+from pyaoscx.route_map_entry import RouteMapEntry
+
+
+def make_session():
+    api = SimpleNamespace(
+        default_selector="writable",
+        default_depth=1,
+        default_facts_depth=2,
+        compound_index_separator=",",
+    )
+    return SimpleNamespace(connected=True, api=api)
+
+
+def test_registry_resolution():
+    session = make_session()
+    from pyaoscx.rest.v10_09.api import v10_09
+
+    api = v10_09()
+    assert api.get_module_class(session, "RouteMap") is RouteMap
+    assert api.get_module_class(session, "RouteMapEntry") is RouteMapEntry
+
+
+def test_route_map_uris():
+    session = make_session()
+    rmap = RouteMap(session, "RM1")
+    assert rmap.name == "RM1"
+    assert rmap.path == "system/route_maps/RM1"
+    assert rmap.base_uri == "system/route_maps"
+    assert RouteMap.indices == ["name"]
+
+
+def test_route_map_create_body():
+    session = make_session()
+    rmap = RouteMap(session, "RM1")
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    rmap._post_data = fake_post
+    assert rmap.create() is True
+    assert captured["name"] == "RM1"
+
+
+def test_route_map_update_strips_name():
+    session = make_session()
+    rmap = RouteMap(session, "RM1", description="x")
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    rmap._put_data = fake_put
+    assert rmap.update() is True
+    assert "name" not in captured
+    assert captured["description"] == "x"
+
+
+def test_route_map_entry_uris():
+    session = make_session()
+    parent = RouteMap(session, "RM1")
+    entry = RouteMapEntry(session, 10, parent, action="permit")
+    assert entry.preference == 10
+    assert entry.path == "system/route_maps/RM1/route_map_entries/10"
+    assert entry.base_uri == "system/route_maps/RM1/route_map_entries"
+    assert RouteMapEntry.indices == ["preference"]
+
+
+def test_route_map_entry_create_body():
+    session = make_session()
+    parent = RouteMap(session, "RM1")
+    entry = RouteMapEntry(
+        session,
+        10,
+        parent,
+        action="permit",
+        match={"source_protocol": "bgp"},
+        set={"local_preference": 200},
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    entry._post_data = fake_post
+    assert entry.create() is True
+    assert captured["preference"] == 10
+    assert captured["action"] == "permit"
+    assert captured["match"] == {"source_protocol": "bgp"}
+    assert captured["set"] == {"local_preference": 200}
+
+
+def test_route_map_entry_update_strips_index():
+    session = make_session()
+    parent = RouteMap(session, "RM1")
+    entry = RouteMapEntry(session, 10, parent, action="deny")
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    entry._put_data = fake_put
+    assert entry.update() is True
+    assert "preference" not in captured
+    assert captured["action"] == "deny"
+
+
+def test_route_map_entry_from_uri():
+    session = make_session()
+    uri = "/rest/v10.09/system/route_maps/RM1/route_map_entries/20"
+    preference, entry = RouteMapEntry.from_uri(session, uri)
+    assert preference == "20"
+    assert isinstance(entry, RouteMapEntry)
+    assert entry.preference == "20"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #44

### Description
Adds `RouteMap` and `RouteMapEntry` resource modules, modeled on the existing resource classes, and registers them in the API module-name table. Route map entries carry nested `match`/`set` clause attributes. Includes offline unit tests covering registry resolution, URIs, and create/update request bodies.

### Testing
- `black --line-length 79` and `flake8` clean (pre-commit hook).
- `pytest tests/test_route_map.py` — 8 passing.
- Validated live against AOS-CX (REST v10.09): create / idempotent re-apply (incl. match & set) / update / entry prune / duplicate-preference refused / delete.

### Notes
- DCO sign-off included.
- `CONTRIBUTING.md` references a `development` branch that does not exist on the repository; this PR targets `master`.

Companion collection PR: aruba/aoscx-ansible-collection#144
