### PR TITLE
Add BgpAspathFilter and BgpAspathFilterEntry resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "BgpAspathFilter": "bgp_aspath_filter",
+            "BgpAspathFilterEntry": "bgp_aspath_filter_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/bgp_aspath_filter.py
+++ b/pyaoscx/bgp_aspath_filter.py
@@ -1,0 +1,230 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class BgpAspathFilter(PyaoscxModule):
+    """
+    Provide configuration management for BGP AS-Path Filters on AOS-CX
+        devices.
+    """
+
+    collection_uri = "system/bgp_aspath_filters"
+    object_uri = collection_uri + "/{name}"
+    resource_uri_name = "name"
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        self.__name = name
+
+        # List used to determine attributes related to the
+        # BGP AS-Path Filter configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URI that identifies the current BGP AS-Path Filter
+        self.path = self.object_uri.format(name=name)
+        self.base_uri = self.collection_uri
+
+    @property
+    def name(self):
+        return self.__name
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a BGP AS-Path Filter and fill
+            the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all BGP AS-Path Filters and create a
+            dictionary containing each of them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing BGP AS-Path Filter names as keys and a
+            BGP AS-Path Filter object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        aspath_filter_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            name, aspath_filter = cls.from_uri(session, uri)
+            aspath_filter_dict[name] = aspath_filter
+
+        return aspath_filter_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing BGP AS-Path
+            Filter. Checks whether the BGP AS-Path Filter exists in the switch
+            and calls self.update() or self.create() accordingly.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing BGP AS-Path Filter.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and cannot be part of the PUT body
+        if "name" in data:
+            del data["name"]
+        self.__modified = self._put_data(data)
+        logging.info("SUCCESS: Updating %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new BGP AS-Path Filter in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and must be added explicitly
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        logging.info("SUCCESS: Adding %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a BGP AS-Path Filter from the switch.
+            All the entries that belong to the filter are removed with it.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a BgpAspathFilter object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the name and the BGP AS-Path Filter.
+        """
+        # The name is the last element of the URI
+        name = uri.split("/")[-1]
+        return name, cls(session, name)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a BgpAspathFilter object given a response_data.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param response_data: The response must be a dictionary of the form:
+            {name: URI}.
+        :return: BgpAspathFilter object.
+        """
+        uri = next(iter(response_data.values()))
+        _, aspath_filter = cls.from_uri(session, uri)
+        return aspath_filter
+
+    @classmethod
+    def get_facts(cls, session):
+        """
+        Retrieve the information of all BGP AS-Path Filters.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the name as key and the facts as value.
+        """
+        logging.info("Retrieving BGP AS-Path Filters facts")
+
+        depth = session.api.default_facts_depth
+
+        try:
+            response = session.request(
+                "GET", cls.collection_uri, params={"depth": depth}
+            )
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "BGP AS-Path Filter {0}".format(self.name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/bgp_aspath_filter_entry.py
+++ b/pyaoscx/bgp_aspath_filter_entry.py
@@ -1,0 +1,234 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.bgp_aspath_filter import BgpAspathFilter
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class BgpAspathFilterEntry(PyaoscxModule):
+    """
+    Provide configuration management for BGP AS-Path Filter Entries on AOS-CX
+        devices.
+    """
+
+    collection_uri = (
+        "system/bgp_aspath_filters/{name}/bgp_aspath_filter_entries"
+    )
+    object_uri = collection_uri + "/{preference}"
+    resource_name = "preference"
+    indices = ["preference"]
+
+    def __init__(self, session, preference, parent_aspath_filter, **kwargs):
+        self.__parent_aspath_filter = parent_aspath_filter
+        self.__preference = preference
+        self.session = session
+
+        # List used to determine attributes related to the
+        # BGP AS-Path Filter Entry configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URIs that identify the current entry
+        self.path = self.object_uri.format(
+            name=self.__parent_aspath_filter.name, preference=preference
+        )
+        self.base_uri = self.collection_uri.format(
+            name=self.__parent_aspath_filter.name
+        )
+
+    @property
+    def preference(self):
+        return self.__preference
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a BGP AS-Path Filter Entry and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, aspath_filter_name):
+        """
+        Perform a GET call to retrieve all entries of the same BGP AS-Path
+            Filter and create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param aspath_filter_name: Name of the BGP AS-Path Filter to which the
+            entries belong.
+        :return: Dictionary containing entry preferences as keys and a BGP
+            AS-Path Filter Entry object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=aspath_filter_name)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        entry_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            preference, entry = cls.from_uri(session, uri)
+            entry_dict[preference] = entry
+
+        return entry_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing BGP AS-Path
+            Filter Entry. Checks whether the entry exists in the switch and
+            calls self.update() or self.create() accordingly.
+
+        :return modified: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing entry.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and cannot be part of the PUT body
+        if "preference" in data:
+            del data["preference"]
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new entry in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and must be added explicitly
+        data["preference"] = self.preference
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a BGP AS-Path Filter Entry from the
+            switch.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a BgpAspathFilterEntry object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the preference and the entry.
+        """
+        # URI format is:
+        # /system/bgp_aspath_filters/{name}/bgp_aspath_filter_entries/{pref}
+        parts = uri.split("/")
+        aspath_filter_name = parts[-3]
+        preference = parts[-1]
+        aspath_filter = BgpAspathFilter(session, aspath_filter_name)
+        entry = cls(session, preference, aspath_filter)
+        return preference, entry
+
+    @classmethod
+    def get_facts(cls, session, aspath_filter_name):
+        """
+        Retrieve the information of all entries of a BGP AS-Path Filter.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param aspath_filter_name: Name of the BGP AS-Path Filter to which the
+            entries belong.
+        :return: Dictionary containing the preference as key and the facts as
+            value.
+        """
+        logging.info("Retrieving BGP AS-Path Filter Entries facts")
+
+        depth = session.api.default_facts_depth
+
+        uri = cls.collection_uri.format(name=aspath_filter_name)
+
+        try:
+            response = session.request("GET", uri, params={"depth": depth})
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "BGP AS-Path Filter Entry {0} of Filter {1}".format(
+            self.preference, self.__parent_aspath_filter.name
+        )
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/tests/test_bgp_aspath_filter.py
+++ b/tests/test_bgp_aspath_filter.py
@@ -1,0 +1,149 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the BgpAspathFilter and BgpAspathFilterEntry modules.
+
+These tests do not require a live switch. They mock the HTTP layer
+(_post_data / _put_data) and verify the request bodies and URIs produced by
+the classes, including the index immutability rules.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pyaoscx.bgp_aspath_filter import BgpAspathFilter
+from pyaoscx.bgp_aspath_filter_entry import BgpAspathFilterEntry
+
+
+def make_session():
+    api = SimpleNamespace(
+        default_selector="writable",
+        default_depth=1,
+        default_facts_depth=2,
+        compound_index_separator=",",
+    )
+    return SimpleNamespace(connected=True, api=api)
+
+
+def test_registry_resolution():
+    session = make_session()
+    from pyaoscx.rest.v10_09.api import v10_09
+
+    api = v10_09()
+    assert api.get_module_class(session, "BgpAspathFilter") is BgpAspathFilter
+    assert (
+        api.get_module_class(session, "BgpAspathFilterEntry")
+        is BgpAspathFilterEntry
+    )
+
+
+def test_filter_uris():
+    session = make_session()
+    flt = BgpAspathFilter(session, "F1")
+    assert flt.name == "F1"
+    assert flt.path == "system/bgp_aspath_filters/F1"
+    assert flt.base_uri == "system/bgp_aspath_filters"
+    assert BgpAspathFilter.indices == ["name"]
+
+
+def test_filter_create_body():
+    session = make_session()
+    flt = BgpAspathFilter(session, "F1", description="x")
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    flt._post_data = fake_post
+    assert flt.create() is True
+    assert captured["name"] == "F1"
+    assert captured["description"] == "x"
+
+
+def test_filter_update_strips_name():
+    session = make_session()
+    flt = BgpAspathFilter(session, "F1", description="x")
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    flt._put_data = fake_put
+    assert flt.update() is True
+    assert "name" not in captured
+    assert captured["description"] == "x"
+
+
+def test_entry_uris():
+    session = make_session()
+    parent = BgpAspathFilter(session, "F1")
+    entry = BgpAspathFilterEntry(session, 10, parent, action="permit")
+    assert entry.preference == 10
+    assert entry.path == (
+        "system/bgp_aspath_filters/F1/bgp_aspath_filter_entries/10"
+    )
+    assert entry.base_uri == (
+        "system/bgp_aspath_filters/F1/bgp_aspath_filter_entries"
+    )
+    assert BgpAspathFilterEntry.indices == ["preference"]
+
+
+def test_entry_create_body():
+    session = make_session()
+    parent = BgpAspathFilter(session, "F1")
+    entry = BgpAspathFilterEntry(
+        session, 10, parent, action="permit", regex="^65000_"
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    entry._post_data = fake_post
+    assert entry.create() is True
+    assert captured["preference"] == 10
+    assert captured["action"] == "permit"
+    assert captured["regex"] == "^65000_"
+
+
+def test_entry_update_strips_index():
+    session = make_session()
+    parent = BgpAspathFilter(session, "F1")
+    entry = BgpAspathFilterEntry(session, 10, parent, action="deny")
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    entry._put_data = fake_put
+    assert entry.update() is True
+    assert "preference" not in captured
+    assert captured["action"] == "deny"
+
+
+def test_entry_from_uri():
+    session = make_session()
+    uri = (
+        "/rest/v10.09/system/bgp_aspath_filters/F1/"
+        "bgp_aspath_filter_entries/20"
+    )
+    preference, entry = BgpAspathFilterEntry.from_uri(session, uri)
+    assert preference == "20"
+    assert isinstance(entry, BgpAspathFilterEntry)
+    assert entry.preference == "20"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Description
Adds resource modules for **BGP AS-Path filters** (REST resource `system/bgp_aspath_filters` and nested `bgp_aspath_filter_entries`):

- `BgpAspathFilter` — index `name`, attribute `description`.
- `BgpAspathFilterEntry` — index `preference`, attributes `action` (permit/deny) and `regex`, nested under a parent filter.

Both classes are modeled on the existing `queue_profile` / `queue_profile_entry` resource modules and are registered in the API module-name table, so they can be obtained via `session.api.get_module(session, "BgpAspathFilter", name)`.

Fixes #46

## Changes
- `pyaoscx/bgp_aspath_filter.py` — new `BgpAspathFilter` resource module.
- `pyaoscx/bgp_aspath_filter_entry.py` — new `BgpAspathFilterEntry` resource module.
- `pyaoscx/api.py` — register both classes in the module-name table.
- `tests/test_bgp_aspath_filter.py` — offline unit tests (registry resolution, URIs, create/update bodies, index immutability, from_uri).

## Testing
- `black --check --line-length 79` and `flake8` clean on all changed files (matches the repo pre-commit hook).
- `pytest tests/test_bgp_aspath_filter.py` — 8 passed.
- Validated end-to-end against a live AOS-CX switch (create / idempotent re-apply / update / prune / delete) through the Ansible collection that consumes these classes.

## Note
`CONTRIBUTING.md` mentions a `development` base branch, but the repository only exposes `master`, so this PR targets `master`. Happy to retarget if a `development` branch is created.

Companion collection PR: aruba/aoscx-ansible-collection#156
