### PR TITLE
Add BgpCommunityFilter and BgpCommunityFilterEntry resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "BgpCommunityFilter": "bgp_community_filter",
+            "BgpCommunityFilterEntry": "bgp_community_filter_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/bgp_community_filter.py
+++ b/pyaoscx/bgp_community_filter.py
@@ -1,0 +1,231 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class BgpCommunityFilter(PyaoscxModule):
+    """
+    Provide configuration management for BGP Community Filters on AOS-CX
+        devices.
+    """
+
+    collection_uri = "system/bgp_community_filters"
+    object_uri = collection_uri + "/{name}"
+    resource_uri_name = "name"
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        self.__name = name
+
+        # List used to determine attributes related to the
+        # BGP Community Filter configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URI that identifies the current BGP Community Filter
+        self.path = self.object_uri.format(name=name)
+        self.base_uri = self.collection_uri
+
+    @property
+    def name(self):
+        return self.__name
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a BGP Community Filter and fill
+            the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all BGP Community Filters and create a
+            dictionary containing each of them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing BGP Community Filter names as keys and a
+            BGP Community Filter object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        community_filter_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            name, community_filter = cls.from_uri(session, uri)
+            community_filter_dict[name] = community_filter
+
+        return community_filter_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing BGP Community
+            Filter. Checks whether the BGP Community Filter exists in the
+            switch and calls self.update() or self.create() accordingly.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing BGP Community
+            Filter.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and cannot be part of the PUT body
+        if "name" in data:
+            del data["name"]
+        self.__modified = self._put_data(data)
+        logging.info("SUCCESS: Updating %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new BGP Community Filter in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and must be added explicitly
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        logging.info("SUCCESS: Adding %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a BGP Community Filter from the switch.
+            All the entries that belong to the filter are removed with it.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a BgpCommunityFilter object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the name and the BGP Community Filter.
+        """
+        # The name is the last element of the URI
+        name = uri.split("/")[-1]
+        return name, cls(session, name)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a BgpCommunityFilter object given a response_data.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param response_data: The response must be a dictionary of the form:
+            {name: URI}.
+        :return: BgpCommunityFilter object.
+        """
+        uri = next(iter(response_data.values()))
+        _, community_filter = cls.from_uri(session, uri)
+        return community_filter
+
+    @classmethod
+    def get_facts(cls, session):
+        """
+        Retrieve the information of all BGP Community Filters.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the name as key and the facts as value.
+        """
+        logging.info("Retrieving BGP Community Filters facts")
+
+        depth = session.api.default_facts_depth
+
+        try:
+            response = session.request(
+                "GET", cls.collection_uri, params={"depth": depth}
+            )
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "BGP Community Filter {0}".format(self.name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/bgp_community_filter_entry.py
+++ b/pyaoscx/bgp_community_filter_entry.py
@@ -1,0 +1,235 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.bgp_community_filter import BgpCommunityFilter
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class BgpCommunityFilterEntry(PyaoscxModule):
+    """
+    Provide configuration management for BGP Community Filter Entries on
+        AOS-CX devices.
+    """
+
+    collection_uri = (
+        "system/bgp_community_filters/{name}/bgp_community_filter_entries"
+    )
+    object_uri = collection_uri + "/{preference}"
+    resource_name = "preference"
+    indices = ["preference"]
+
+    def __init__(self, session, preference, parent_community_filter, **kwargs):
+        self.__parent_community_filter = parent_community_filter
+        self.__preference = preference
+        self.session = session
+
+        # List used to determine attributes related to the
+        # BGP Community Filter Entry configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URIs that identify the current entry
+        self.path = self.object_uri.format(
+            name=self.__parent_community_filter.name, preference=preference
+        )
+        self.base_uri = self.collection_uri.format(
+            name=self.__parent_community_filter.name
+        )
+
+    @property
+    def preference(self):
+        return self.__preference
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a BGP Community Filter Entry
+            and fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, community_filter_name):
+        """
+        Perform a GET call to retrieve all entries of the same BGP Community
+            Filter and create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param community_filter_name: Name of the BGP Community Filter to which
+            the entries belong.
+        :return: Dictionary containing entry preferences as keys and a BGP
+            Community Filter Entry object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=community_filter_name)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        entry_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            preference, entry = cls.from_uri(session, uri)
+            entry_dict[preference] = entry
+
+        return entry_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing BGP Community
+            Filter Entry. Checks whether the entry exists in the switch and
+            calls self.update() or self.create() accordingly.
+
+        :return modified: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing entry.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and cannot be part of the PUT body
+        if "preference" in data:
+            del data["preference"]
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new entry in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The preference is an index and must be added explicitly
+        data["preference"] = self.preference
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a BGP Community Filter Entry from the
+            switch.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a BgpCommunityFilterEntry object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the preference and the entry.
+        """
+        # URI format is:
+        # /system/bgp_community_filters/{name}/bgp_community_filter_entries
+        #   /{preference}
+        parts = uri.split("/")
+        community_filter_name = parts[-3]
+        preference = parts[-1]
+        community_filter = BgpCommunityFilter(session, community_filter_name)
+        entry = cls(session, preference, community_filter)
+        return preference, entry
+
+    @classmethod
+    def get_facts(cls, session, community_filter_name):
+        """
+        Retrieve the information of all entries of a BGP Community Filter.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param community_filter_name: Name of the BGP Community Filter to which
+            the entries belong.
+        :return: Dictionary containing the preference as key and the facts as
+            value.
+        """
+        logging.info("Retrieving BGP Community Filter Entries facts")
+
+        depth = session.api.default_facts_depth
+
+        uri = cls.collection_uri.format(name=community_filter_name)
+
+        try:
+            response = session.request("GET", uri, params={"depth": depth})
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "BGP Community Filter Entry {0} of Filter {1}".format(
+            self.preference, self.__parent_community_filter.name
+        )
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/tests/test_bgp_community_filter.py
+++ b/tests/test_bgp_community_filter.py
@@ -1,0 +1,159 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the BgpCommunityFilter and BgpCommunityFilterEntry
+modules.
+
+These tests do not require a live switch. They mock the HTTP layer
+(_post_data / _put_data) and verify the request bodies and URIs produced by
+the classes, including the index immutability rules.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pyaoscx.bgp_community_filter import BgpCommunityFilter
+from pyaoscx.bgp_community_filter_entry import BgpCommunityFilterEntry
+
+
+def make_session():
+    api = SimpleNamespace(
+        default_selector="writable",
+        default_depth=1,
+        default_facts_depth=2,
+        compound_index_separator=",",
+    )
+    return SimpleNamespace(connected=True, api=api)
+
+
+def test_registry_resolution():
+    session = make_session()
+    from pyaoscx.rest.v10_09.api import v10_09
+
+    api = v10_09()
+    assert (
+        api.get_module_class(session, "BgpCommunityFilter")
+        is BgpCommunityFilter
+    )
+    assert (
+        api.get_module_class(session, "BgpCommunityFilterEntry")
+        is BgpCommunityFilterEntry
+    )
+
+
+def test_filter_uris():
+    session = make_session()
+    flt = BgpCommunityFilter(session, "C1")
+    assert flt.name == "C1"
+    assert flt.path == "system/bgp_community_filters/C1"
+    assert flt.base_uri == "system/bgp_community_filters"
+    assert BgpCommunityFilter.indices == ["name"]
+
+
+def test_filter_create_body():
+    session = make_session()
+    flt = BgpCommunityFilter(
+        session, "C1", type="community-list", description="x"
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    flt._post_data = fake_post
+    assert flt.create() is True
+    assert captured["name"] == "C1"
+    assert captured["type"] == "community-list"
+    assert captured["description"] == "x"
+
+
+def test_filter_update_strips_name():
+    session = make_session()
+    flt = BgpCommunityFilter(
+        session, "C1", type="community-list", description="x"
+    )
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    flt._put_data = fake_put
+    assert flt.update() is True
+    assert "name" not in captured
+    assert captured["type"] == "community-list"
+    assert captured["description"] == "x"
+
+
+def test_entry_uris():
+    session = make_session()
+    parent = BgpCommunityFilter(session, "C1")
+    entry = BgpCommunityFilterEntry(session, 10, parent, action="permit")
+    assert entry.preference == 10
+    assert entry.path == (
+        "system/bgp_community_filters/C1/bgp_community_filter_entries/10"
+    )
+    assert entry.base_uri == (
+        "system/bgp_community_filters/C1/bgp_community_filter_entries"
+    )
+    assert BgpCommunityFilterEntry.indices == ["preference"]
+
+
+def test_entry_create_body():
+    session = make_session()
+    parent = BgpCommunityFilter(session, "C1")
+    entry = BgpCommunityFilterEntry(
+        session, 10, parent, action="permit", match_string="65000:1"
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    entry._post_data = fake_post
+    assert entry.create() is True
+    assert captured["preference"] == 10
+    assert captured["action"] == "permit"
+    assert captured["match_string"] == "65000:1"
+
+
+def test_entry_update_strips_index():
+    session = make_session()
+    parent = BgpCommunityFilter(session, "C1")
+    entry = BgpCommunityFilterEntry(session, 10, parent, action="deny")
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    entry._put_data = fake_put
+    assert entry.update() is True
+    assert "preference" not in captured
+    assert captured["action"] == "deny"
+
+
+def test_entry_from_uri():
+    session = make_session()
+    uri = (
+        "/rest/v10.09/system/bgp_community_filters/C1/"
+        "bgp_community_filter_entries/20"
+    )
+    preference, entry = BgpCommunityFilterEntry.from_uri(session, uri)
+    assert preference == "20"
+    assert isinstance(entry, BgpCommunityFilterEntry)
+    assert entry.preference == "20"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Description
Adds resource modules for **BGP community filters** (REST resource `system/bgp_community_filters` and nested `bgp_community_filter_entries`):

- `BgpCommunityFilter` — index `name`, attributes `type` (community-list / community-expanded-list / extcommunity-list / extcommunity-expanded-list) and `description`.
- `BgpCommunityFilterEntry` — index `preference`, attributes `action` (permit/deny) and `match_string`, nested under a parent filter.

Both classes are modeled on the existing `queue_profile` / `queue_profile_entry` resource modules and are registered in the API module-name table, so they can be obtained via `session.api.get_module(session, "BgpCommunityFilter", name)`.

Fixes #48

## Changes
- `pyaoscx/bgp_community_filter.py` — new `BgpCommunityFilter` resource module.
- `pyaoscx/bgp_community_filter_entry.py` — new `BgpCommunityFilterEntry` resource module.
- `pyaoscx/api.py` — register both classes in the module-name table.
- `tests/test_bgp_community_filter.py` — offline unit tests (registry resolution, URIs, create/update bodies, index immutability, from_uri).

## Testing
- `black --check --line-length 79` and `flake8` clean on all changed files (matches the repo pre-commit hook).
- `pytest tests/test_bgp_community_filter.py` — 8 passed.
- Validated end-to-end against a live AOS-CX switch (create / idempotent re-apply / update / prune / delete) through the Ansible collection that consumes these classes.

## Note
`CONTRIBUTING.md` mentions a `development` base branch, but the repository only exposes `master`, so this PR targets `master`. Happy to retarget if a `development` branch is created.

Companion collection PR: aruba/aoscx-ansible-collection#157
