### PR TITLE
Add PbrActionList and PbrActionListEntry resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "PbrActionList": "pbr_action_list",
+            "PbrActionListEntry": "pbr_action_list_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/pbr_action_list.py
+++ b/pyaoscx/pbr_action_list.py
@@ -1,0 +1,230 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class PbrActionList(PyaoscxModule):
+    """
+    Provide configuration management for PBR (Policy Based Routing) Action
+        Lists on AOS-CX devices.
+    """
+
+    collection_uri = "system/pbr_action_lists"
+    object_uri = collection_uri + "/{name}"
+    resource_uri_name = "name"
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        self.__name = name
+
+        # List used to determine attributes related to the
+        # PBR Action List configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URI that identifies the current PBR Action List
+        self.path = self.object_uri.format(name=name)
+        self.base_uri = self.collection_uri
+
+    @property
+    def name(self):
+        return self.__name
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a PBR Action List and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all PBR Action Lists and create a
+            dictionary containing each of them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing PBR Action List names as keys and a PBR
+            Action List object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        action_list_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            name, action_list = cls.from_uri(session, uri)
+            action_list_dict[name] = action_list
+
+        return action_list_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing PBR Action
+            List. Checks whether the PBR Action List exists in the switch and
+            calls self.update() or self.create() accordingly.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing PBR Action List.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and cannot be part of the PUT body
+        if "name" in data:
+            del data["name"]
+        self.__modified = self._put_data(data)
+        logging.info("SUCCESS: Updating %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new PBR Action List in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The name is an index and must be added explicitly
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        logging.info("SUCCESS: Adding %s", self)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a PBR Action List from the switch. All
+            the entries that belong to the list are removed with it.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a PbrActionList object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the name and the PBR Action List.
+        """
+        # The name is the last element of the URI
+        name = uri.split("/")[-1]
+        return name, cls(session, name)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a PbrActionList object given a response_data.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param response_data: The response must be a dictionary of the form:
+            {name: URI}.
+        :return: PbrActionList object.
+        """
+        uri = next(iter(response_data.values()))
+        _, action_list = cls.from_uri(session, uri)
+        return action_list
+
+    @classmethod
+    def get_facts(cls, session):
+        """
+        Retrieve the information of all PBR Action Lists.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the name as key and the facts as value.
+        """
+        logging.info("Retrieving PBR Action Lists facts")
+
+        depth = session.api.default_facts_depth
+
+        try:
+            response = session.request(
+                "GET", cls.collection_uri, params={"depth": depth}
+            )
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "PBR Action List {0}".format(self.name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/pbr_action_list_entry.py
+++ b/pyaoscx/pbr_action_list_entry.py
@@ -1,0 +1,238 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pbr_action_list import PbrActionList
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class PbrActionListEntry(PyaoscxModule):
+    """
+    Provide configuration management for PBR Action List Entries on AOS-CX
+        devices. The switch does not support modifying an existing entry, so
+        a change is applied by deleting and recreating the entry.
+    """
+
+    collection_uri = "system/pbr_action_lists/{name}/cfg_entries"
+    object_uri = collection_uri + "/{sequence_number}"
+    resource_name = "sequence_number"
+    indices = ["sequence_number"]
+
+    def __init__(self, session, sequence_number, parent_action_list, **kwargs):
+        self.__parent_action_list = parent_action_list
+        self.__sequence_number = sequence_number
+        self.session = session
+
+        # List used to determine attributes related to the
+        # PBR Action List Entry configuration
+        self.config_attrs = []
+        self.materialized = False
+
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET request
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+
+        # Used to know if the object was changed since the last request
+        self.__modified = False
+
+        # Build the URIs that identify the current entry
+        self.path = self.object_uri.format(
+            name=self.__parent_action_list.name,
+            sequence_number=sequence_number,
+        )
+        self.base_uri = self.collection_uri.format(
+            name=self.__parent_action_list.name
+        )
+
+    @property
+    def sequence_number(self):
+        return self.__sequence_number
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a PBR Action List Entry and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if no exception is raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        selector = selector or self.session.api.default_selector
+
+        data = self._get_data(depth, selector)
+
+        # Add dictionary as attributes for the object
+        utils.create_attrs(self, data)
+
+        # Update the original attributes
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, action_list_name):
+        """
+        Perform a GET call to retrieve all entries of the same PBR Action List
+            and create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param action_list_name: Name of the PBR Action List to which the
+            entries belong.
+        :return: Dictionary containing entry sequence numbers as keys and a PBR
+            Action List Entry object as value.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=action_list_name)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        entry_dict = {}
+        # Get all URI elements in the form of a list
+        uri_list = session.api.get_uri_from_data(data)
+
+        for uri in uri_list:
+            sequence_number, entry = cls.from_uri(session, uri)
+            entry_dict[sequence_number] = entry
+
+        return entry_dict
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing PBR Action
+            List Entry. Checks whether the entry exists in the switch and
+            calls self.update() or self.create() accordingly.
+
+        :return modified: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing entry.
+
+        Note: the switch does not allow modifying a PBR Action List Entry in
+            place. Callers that need to change an entry must delete it and
+            create it again.
+
+        :return: True if the object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The sequence number is an index and cannot be part of the PUT body
+        if "sequence_number" in data:
+            del data["sequence_number"]
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new entry in the switch.
+
+        :return: True if the object was modified.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The sequence number is an index and must be added explicitly
+        data["sequence_number"] = self.sequence_number
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to remove a PBR Action List Entry from the
+            switch.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a PbrActionListEntry object given an URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a string with the URI.
+        :return: tuple with the sequence number and the entry.
+        """
+        # URI format is:
+        # /system/pbr_action_lists/{name}/cfg_entries/{sequence_number}
+        parts = uri.split("/")
+        action_list_name = parts[-3]
+        sequence_number = parts[-1]
+        action_list = PbrActionList(session, action_list_name)
+        entry = cls(session, sequence_number, action_list)
+        return sequence_number, entry
+
+    @classmethod
+    def get_facts(cls, session, action_list_name):
+        """
+        Retrieve the information of all entries of a PBR Action List.
+
+        :param cls: Class reference.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param action_list_name: Name of the PBR Action List to which the
+            entries belong.
+        :return: Dictionary containing the sequence number as key and the
+            facts as value.
+        """
+        logging.info("Retrieving PBR Action List Entries facts")
+
+        depth = session.api.default_facts_depth
+
+        uri = cls.collection_uri.format(name=action_list_name)
+
+        try:
+            response = session.request("GET", uri, params={"depth": depth})
+        except Exception as exc:
+            raise ResponseError("GET", exc)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        return json.loads(response.text)
+
+    def __str__(self):
+        return "PBR Action List Entry {0} of List {1}".format(
+            self.sequence_number, self.__parent_action_list.name
+        )
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/tests/test_pbr_action_list.py
+++ b/tests/test_pbr_action_list.py
@@ -1,0 +1,165 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the PbrActionList and PbrActionListEntry modules.
+
+These tests do not require a live switch. They mock the HTTP layer
+(_post_data / _put_data) and verify the request bodies and URIs produced by
+the classes, including the index immutability rules.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pyaoscx.pbr_action_list import PbrActionList
+from pyaoscx.pbr_action_list_entry import PbrActionListEntry
+
+
+def make_session():
+    api = SimpleNamespace(
+        default_selector="writable",
+        default_depth=1,
+        default_facts_depth=2,
+        compound_index_separator=",",
+    )
+    return SimpleNamespace(connected=True, api=api)
+
+
+def test_registry_resolution():
+    session = make_session()
+    from pyaoscx.rest.v10_09.api import v10_09
+
+    api = v10_09()
+    assert api.get_module_class(session, "PbrActionList") is PbrActionList
+    assert (
+        api.get_module_class(session, "PbrActionListEntry")
+        is PbrActionListEntry
+    )
+
+
+def test_action_list_uris():
+    session = make_session()
+    pal = PbrActionList(session, "PBR1")
+    assert pal.name == "PBR1"
+    assert pal.path == "system/pbr_action_lists/PBR1"
+    assert pal.base_uri == "system/pbr_action_lists"
+    assert PbrActionList.indices == ["name"]
+
+
+def test_action_list_create_body():
+    session = make_session()
+    pal = PbrActionList(
+        session, "PBR1", vsx_sync=["all_attributes_and_dependents"]
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    pal._post_data = fake_post
+    assert pal.create() is True
+    assert captured["name"] == "PBR1"
+    assert captured["vsx_sync"] == ["all_attributes_and_dependents"]
+
+
+def test_action_list_update_strips_name():
+    session = make_session()
+    pal = PbrActionList(session, "PBR1", vsx_sync=[])
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    pal._put_data = fake_put
+    assert pal.update() is True
+    assert "name" not in captured
+    assert captured["vsx_sync"] == []
+
+
+def test_entry_uris():
+    session = make_session()
+    parent = PbrActionList(session, "PBR1")
+    entry = PbrActionListEntry(session, 10, parent, type="blackhole")
+    assert entry.sequence_number == 10
+    assert entry.path == ("system/pbr_action_lists/PBR1/cfg_entries/10")
+    assert entry.base_uri == ("system/pbr_action_lists/PBR1/cfg_entries")
+    assert PbrActionListEntry.indices == ["sequence_number"]
+
+
+def test_entry_create_body_nexthop():
+    session = make_session()
+    parent = PbrActionList(session, "PBR1")
+    entry = PbrActionListEntry(
+        session, 10, parent, type="nexthop", ip="10.0.0.1"
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    entry._post_data = fake_post
+    assert entry.create() is True
+    assert captured["sequence_number"] == 10
+    assert captured["type"] == "nexthop"
+    assert captured["ip"] == "10.0.0.1"
+
+
+def test_entry_create_body_interface():
+    session = make_session()
+    parent = PbrActionList(session, "PBR1")
+    uri = "/rest/v10.09/system/interfaces/1%2F1%2F1"
+    entry = PbrActionListEntry(
+        session, 20, parent, type="interface", interface=uri
+    )
+
+    captured = {}
+
+    def fake_post(data):
+        captured.update(data)
+        return True
+
+    entry._post_data = fake_post
+    assert entry.create() is True
+    assert captured["sequence_number"] == 20
+    assert captured["type"] == "interface"
+    assert captured["interface"] == uri
+
+
+def test_entry_update_strips_index():
+    session = make_session()
+    parent = PbrActionList(session, "PBR1")
+    entry = PbrActionListEntry(session, 10, parent, type="blackhole")
+
+    captured = {}
+
+    def fake_put(data):
+        captured.clear()
+        captured.update(data)
+        return True
+
+    entry._put_data = fake_put
+    assert entry.update() is True
+    assert "sequence_number" not in captured
+    assert captured["type"] == "blackhole"
+
+
+def test_entry_from_uri():
+    session = make_session()
+    uri = "/rest/v10.09/system/pbr_action_lists/PBR1/cfg_entries/30"
+    sequence_number, entry = PbrActionListEntry.from_uri(session, uri)
+    assert sequence_number == "30"
+    assert isinstance(entry, PbrActionListEntry)
+    assert entry.sequence_number == "30"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Fixes #50

## What

Add SDK support for **Policy Based Routing (PBR) action lists** and their entries:

- `pyaoscx/pbr_action_list.py` — `PbrActionList` (collection `system/pbr_action_lists`, index `name`, attribute `vsx_sync`).
- `pyaoscx/pbr_action_list_entry.py` — `PbrActionListEntry` (nested `cfg_entries`, index `sequence_number`, attributes `type`, `ip`, `interface`).
- `pyaoscx/api.py` — both classes registered in the module-name table.
- `tests/test_pbr_action_list.py` — 9 offline unit tests (registry resolution, URIs, create/update bodies, index immutability, `from_uri`).

## Behaviour notes

- An entry's `type` selects which field is required: `ip` for `nexthop`/`default_nexthop`, `interface` (a `system/interfaces` URI ref) for `interface`, and nothing for `blackhole`.
- On the switch a PBR entry object exposes only GET and DELETE (no PUT/PATCH). Entries are therefore immutable; the `update()` method is kept for class symmetry and documented as such — callers change an entry by deleting and recreating it.

## Testing

- `black --check --line-length 79` and `flake8` clean on all changed files.
- `pytest tests/test_pbr_action_list.py` — 9/9 passing.
- Exercised end-to-end against a live Aruba CX 6300 switch (firmware FL.10.17.1001, REST API v10.09) via the Ansible collection: create, idempotent re-apply, delete-and-recreate on change, prune and delete.

## Note on contribution process

`CONTRIBUTING.md` mentions a `development` branch as the PR target, but the repository only has `master`, so this PR targets `master`.

Companion collection PR: aruba/aoscx-ansible-collection#149
