### PR TITLE
Fix DhcpRelay.get_all crash on compound index parsing

### DIFF
--- a/pyaoscx/dhcp_relay.py
+++ b/pyaoscx/dhcp_relay.py
@@ -313,9 +313,12 @@ class DhcpRelay(PyaoscxModule):
         :return: tuple containing both the indices and
             DhcpRelay object.
         """
-        # Obtain ID from URI
+        # Obtain ID from URI. The two indices (vrf and port) are joined by
+        # the compound index separator (a comma), not a slash: the port name
+        # itself is percent-encoded in the URI (for example "1%2F1%2F3"), so
+        # splitting on "/" never matches.
         index_pattern = re.compile(
-            r"(.*)dhcp_relays/(?P<index1>.+)/(?P<index2>.+)"
+            r"(.*)dhcp_relays/(?P<index1>[^,]+),(?P<index2>.+)"
         )
         vrf = index_pattern.match(uri).group("index1")
         port = index_pattern.match(uri).group("index2")

--- a/tests/test_dhcp_relay.py
+++ b/tests/test_dhcp_relay.py
@@ -1,0 +1,87 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the DhcpRelay module.
+
+These tests do not require a live switch. They focus on the compound-index
+parsing in ``from_uri`` / ``get_all``: the two indices (vrf and port) are
+joined in the URI by the compound index separator (a comma), and the port
+name is percent-encoded, e.g. ``dhcp_relays/default,1%2F1%2F3``.
+"""
+
+import json
+
+from types import SimpleNamespace
+
+from pyaoscx.dhcp_relay import DhcpRelay
+
+
+def make_session():
+    """Session whose get_module records calls and returns named stubs."""
+    calls = []
+
+    def get_module(session, module, index, **kwargs):
+        calls.append(SimpleNamespace(module=module, index=index))
+        return SimpleNamespace(name=index)
+
+    def get_uri_from_data(data):
+        return list(data.values())
+
+    api = SimpleNamespace(
+        compound_index_separator=",",
+        get_module=get_module,
+        get_uri_from_data=get_uri_from_data,
+    )
+    session = SimpleNamespace(api=api, calls=calls)
+    return session
+
+
+def test_from_uri_parses_comma_separated_index():
+    session = make_session()
+    uri = "/rest/v10.09/system/dhcp_relays/default,1%2F1%2F3"
+
+    indices, relay = DhcpRelay.from_uri(session, uri)
+
+    # The index string keeps the vrf and the percent-encoded port name.
+    assert indices == "default,1%2F1%2F3"
+    assert isinstance(relay, DhcpRelay)
+    # The port index is everything after the first comma (not split on "/").
+    modules = {c.module: c.index for c in session.calls}
+    assert modules["Vrf"] == "default"
+    assert modules["Interface"] == "1%2F1%2F3"
+
+
+def test_from_uri_vrf_with_underscores():
+    session = make_session()
+    uri = "/rest/v10.09/system/dhcp_relays/mgmt_vrf,vlan204"
+
+    indices, relay = DhcpRelay.from_uri(session, uri)
+
+    assert indices == "mgmt_vrf,vlan204"
+    modules = {c.module: c.index for c in session.calls}
+    assert modules["Vrf"] == "mgmt_vrf"
+    assert modules["Interface"] == "vlan204"
+
+
+def test_get_all_builds_dict_keyed_by_indices():
+    session = make_session()
+
+    def request(method, uri, params=None, data=None):
+        body = {
+            "default,1%2F1%2F3": (
+                "/rest/v10.09/system/dhcp_relays/default,1%2F1%2F3"
+            ),
+            "default,vlan204": (
+                "/rest/v10.09/system/dhcp_relays/default,vlan204"
+            ),
+        }
+        return SimpleNamespace(status_code=200, text=json.dumps(body))
+
+    session.request = request
+
+    result = DhcpRelay.get_all(session)
+
+    assert set(result.keys()) == {"default,1%2F1%2F3", "default,vlan204"}
+    for relay in result.values():
+        assert isinstance(relay, DhcpRelay)


### PR DESCRIPTION
Fixes #54

## Problem

`DhcpRelay.get_all()` raises `AttributeError: 'NoneType' object has no attribute 'group'` whenever the switch has at least one DHCP relay configured.

`DhcpRelay.from_uri()` built its index regex with a slash between the two indices:

```python
r"(.*)dhcp_relays/(?P<index1>.+)/(?P<index2>.+)"
```

On the switch the two indices (`vrf` and `port`) are joined by the compound index separator (a comma) and the port name is percent-encoded, e.g. `dhcp_relays/default,1%2F1%2F3`. There is no literal `/`, so `re.match` returns `None` and `.group(...)` fails.

## Fix

Parse the index on the comma separator instead:

```python
r"(.*)dhcp_relays/(?P<index1>[^,]+),(?P<index2>.+)"
```

The percent-encoded port name is passed through unchanged; `Interface` already decodes `%2F` in its constructor.

## Testing

- `black --check --line-length 79` and `flake8` clean.
- New `tests/test_dhcp_relay.py` (3 offline tests) covering `from_uri` (comma-separated index, vrf with underscores) and `get_all` (dict keyed by indices). `pytest` 3/3 passing.
- Verified live against an Aruba CX 6300 (firmware FL.10.17.1001, REST API v10.09): `DhcpRelay.get_all()` now returns the relays keyed by `vrf,port` with correctly decoded port names, instead of raising.

## Note on contribution process

`CONTRIBUTING.md` mentions a `development` branch as the PR target, but the repository only has `master`, so this PR targets `master`.

Companion collection PR: aruba/aoscx-ansible-collection#146
