### PR TITLE
Fix delete_attrs crash on read-only properties (Vni.delete)

### DIFF
--- a/pyaoscx/utils/util.py
+++ b/pyaoscx/utils/util.py
@@ -226,6 +226,11 @@ def delete_attrs(obj, attr_list):
     """
     for attr in attr_list:
         if hasattr(obj, attr):
+            # Skip class-level data descriptors such as read-only properties:
+            # they are not instance attributes and delattr would raise
+            # AttributeError ("property ... has no deleter").
+            if isinstance(getattr(type(obj), attr, None), property):
+                continue
             delattr(obj, attr)
 
 

--- a/tests/test_util_delete_attrs.py
+++ b/tests/test_util_delete_attrs.py
@@ -1,0 +1,43 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for pyaoscx.utils.util.delete_attrs.
+
+delete_attrs must remove plain instance attributes but must not attempt to
+delete class-level read-only properties (which would raise AttributeError:
+"property ... has no deleter").
+"""
+
+import pyaoscx.utils.util as utils
+
+
+class WithProperty:
+    def __init__(self):
+        self.plain = "value"
+        self._hidden = "ro"
+
+    @property
+    def readonly(self):
+        return self._hidden
+
+
+def test_delete_attrs_removes_plain_attribute():
+    obj = WithProperty()
+    utils.delete_attrs(obj, ["plain"])
+    assert not hasattr(obj, "plain")
+
+
+def test_delete_attrs_skips_readonly_property():
+    obj = WithProperty()
+    # Must not raise even though "readonly" is a property without a deleter.
+    utils.delete_attrs(obj, ["readonly", "plain"])
+    # The property is still accessible, the plain attribute is gone.
+    assert obj.readonly == "ro"
+    assert not hasattr(obj, "plain")
+
+
+def test_delete_attrs_ignores_missing_attribute():
+    obj = WithProperty()
+    utils.delete_attrs(obj, ["does_not_exist"])
+    assert obj.plain == "value"


### PR DESCRIPTION
Fixes #56

## Problem

`Vni.delete()` raises `AttributeError: property 'interface' of 'Vni' object has no deleter`. The REST DELETE succeeds, but the attribute cleanup that runs immediately after crashes.

`utils.delete_attrs` calls `delattr(obj, attr)` for every name in the list. After a GET, `Vni.config_attrs` contains `interface`, which is a class-level read-only property (`Vni.interface`); `delattr` on it raises because the property has no deleter.

## Fix

Skip class-level data descriptors (properties) in `delete_attrs`:

```python
if isinstance(getattr(type(obj), attr, None), property):
    continue
```

Such names are not instance attributes and `delattr` could never remove them anyway, so behaviour for all existing (plain-attribute) callers is unchanged.

## Testing

- `black --check --line-length 79` and `flake8` clean.
- New `tests/test_util_delete_attrs.py` (3 offline tests: plain attribute removed, read-only property skipped without raising, missing attribute ignored). `pytest` 3/3.
- Verified live against an Aruba CX 6300 (firmware FL.10.17.1001, REST API v10.09): creating a VNI, GET with the `writable` selector (so `config_attrs` includes `interface`) and then `delete()` now completes cleanly; the VNI is removed and no exception is raised.

## Note on contribution process

`CONTRIBUTING.md` mentions a `development` branch as the PR target, but the repository only has `master`, so this PR targets `master`.

Companion collection PR: aruba/aoscx-ansible-collection#155
