### PR TITLE
Add resource modules for EVPN (system/evpn and evpn_vlans)

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -167,6 +167,8 @@ class API(ABC):
             "QueueProfileEntry": "queue_profile_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
+            "Evpn": "evpn",
+            "EvpnVlan": "evpn_vlan",
         }
         if name not in module_names:
             raise ParameterError(
@@ -193,6 +195,8 @@ class API(ABC):
             )
         elif module == "Vsx":
             return self._create_vsx(module_class, session, **kwargs)
+        elif module == "Evpn":
+            return module_class(session, **kwargs)
         else:
             return module_class(session, index_id, **kwargs)
 

--- a/pyaoscx/evpn.py
+++ b/pyaoscx/evpn.py
@@ -1,0 +1,141 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import logging
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class Evpn(PyaoscxModule):
+    """
+    Provide configuration management for the global EVPN (Ethernet VPN)
+        settings on AOS-CX devices. This is a singleton resource located at
+        system/evpn.
+    """
+
+    base_uri = "system/evpn"
+    path = "system/evpn"
+
+    def __init__(self, session, **kwargs):
+        self.session = session
+        # List used to determine attributes related to the EVPN configuration
+        self.config_attrs = []
+        self.materialized = False
+        # Attribute dictionary used to manage the original data
+        # obtained from the GET
+        self._original_attributes = {}
+        # Set arguments needed for correct creation
+        utils.set_creation_attrs(self, **kwargs)
+        # Attribute used to know if object was changed recently
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for the EVPN configuration and
+            fill the class with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        # this is common for all PyaoscxModule derived classes
+        self._get_and_copy_data(depth, selector)
+        # Sets object as materialized
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Not applicable for EVPN, it is a singleton resource.
+        """
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an Evpn object given an EVPN URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Evpn object.
+        """
+        return cls(session, uri=uri)
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to update the global EVPN configuration. Since EVPN
+            is a singleton it always exists, so this calls update().
+
+        :return: True if object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to the EVPN configuration.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        put_data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(put_data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to set the EVPN configuration. Only returns if no
+            exception is raised.
+
+        :return: True if entry was created.
+        """
+        post_data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._post_data(post_data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to reset the EVPN configuration.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific EVPN URI.
+
+        :return: Object's URI.
+        """
+        return self.path
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Not applicable for EVPN.
+        """
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/evpn.py
+++ b/pyaoscx/evpn.py
@@ -18,7 +18,7 @@ class Evpn(PyaoscxModule):
     base_uri = "system/evpn"
     path = "system/evpn"
 
-    def __init__(self, session, **kwargs):
+    def __init__(self, session, uri=None, **kwargs):
         self.session = session
         # List used to determine attributes related to the EVPN configuration
         self.config_attrs = []

--- a/pyaoscx/evpn_vlan.py
+++ b/pyaoscx/evpn_vlan.py
@@ -1,0 +1,173 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class EvpnVlan(PyaoscxModule):
+    """
+    Provide configuration management for the per-VLAN EVPN settings on AOS-CX
+        devices. These resources live under system/evpn/evpn_vlans and are
+        indexed by the VLAN ID.
+    """
+
+    collection_uri = "system/evpn/evpn_vlans"
+    object_uri = collection_uri + "/{vlan}"
+
+    indices = ["vlan"]
+    resource_uri_name = "evpn_vlans"
+
+    def __init__(self, session, vlan, **kwargs):
+        self.session = session
+        # The index is the VLAN ID, represented as a string by the REST API
+        self.vlan = str(vlan)
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        # Set arguments needed for correct creation
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri
+        self.path = self.object_uri.format(vlan=self.vlan)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an EVPN VLAN table entry and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all EVPN VLAN entries and create a
+            dictionary containing each respective EVPN VLAN.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing VLAN IDs as keys and EvpnVlan objects
+            as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for uri in data.values():
+            vlan_id, evpn_vlan = cls.from_uri(session, uri)
+            collection[vlan_id] = evpn_vlan
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an EvpnVlan object given an EVPN VLAN URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the VLAN ID and the EvpnVlan object.
+        """
+        # The URI ends with the VLAN ID, e.g. system/evpn/evpn_vlans/204
+        vlan_id = uri.rstrip("/").split("/")[-1]
+        evpn_vlan = cls(session, vlan_id)
+        return vlan_id, evpn_vlan
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an EVPN VLAN table entry.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing EVPN VLAN entry.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new EVPN VLAN entry using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The REST API expects the "vlan" attribute as a URI reference to the
+        # VLAN resource (the plain VLAN ID is rejected with a 500 error).
+        data["vlan"] = "{0}system/vlans/{1}".format(
+            self.session.resource_prefix, self.vlan
+        )
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the EVPN VLAN table entry.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific EVPN VLAN URI.
+
+        :return: Object's URI.
+        """
+        return self.path
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/tests/test_evpn.py
+++ b/tests/test_evpn.py
@@ -1,0 +1,158 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the Evpn and EvpnVlan pyaoscx resource modules.
+
+The pyaoscx Session is mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.evpn import Evpn
+from pyaoscx.evpn_vlan import EvpnVlan
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["configuration", "writable"]
+    api.valid_depth = lambda depth: True
+    session.resource_prefix = "/rest/v10.09/"
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# Evpn (singleton)
+# --------------------------------------------------------------------------
+def test_evpn_path():
+    session = make_session()
+    evpn = Evpn(session)
+    assert evpn.path == "system/evpn"
+    assert evpn.base_uri == "system/evpn"
+
+
+def test_evpn_get_populates_config_attrs():
+    body = {
+        "arp_suppression_enable": True,
+        "mac_move_count": 5,
+        "mac_move_timer": 180,
+        "nd_suppression_enable": False,
+        "redistribute": {"local-mac": False},
+    }
+    session = make_session(get_body=body)
+    evpn = Evpn(session)
+    evpn.get(selector="writable")
+    assert evpn.materialized is True
+    assert set(evpn.config_attrs) == set(body.keys())
+    assert evpn.mac_move_timer == 180
+
+
+def test_evpn_update_idempotent():
+    body = {"mac_move_timer": 180}
+    session = make_session(get_body=body)
+    evpn = Evpn(session)
+    evpn.get(selector="writable")
+    assert evpn.update() is False
+    evpn.mac_move_timer = 181
+    assert evpn.update() is True
+
+
+def test_evpn_from_uri():
+    session = make_session()
+    evpn = Evpn.from_uri(session, "system/evpn")
+    assert isinstance(evpn, Evpn)
+
+
+# --------------------------------------------------------------------------
+# EvpnVlan (child, indexed by vlan)
+# --------------------------------------------------------------------------
+def test_evpn_vlan_path():
+    session = make_session()
+    ev = EvpnVlan(session, 204)
+    assert ev.path == "system/evpn/evpn_vlans/204"
+    assert ev.vlan == "204"
+
+
+def test_evpn_vlan_from_uri():
+    session = make_session()
+    vlan_id, ev = EvpnVlan.from_uri(
+        session, "/rest/v10.09/system/evpn/evpn_vlans/204"
+    )
+    assert vlan_id == "204"
+    assert ev.vlan == "204"
+
+
+def test_evpn_vlan_create_sends_vlan_uri():
+    get_body = {
+        "rd": "65000:3999",
+        "export_route_targets": ["65000:3999"],
+        "import_route_targets": ["65000:3999"],
+        "vlan": "3999",
+    }
+    session = make_session(get_body=get_body)
+    ev = EvpnVlan(session, 3999, rd="65000:3999")
+    ev.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["data"]["vlan"] == "/rest/v10.09/system/vlans/3999"
+    assert post["data"]["rd"] == "65000:3999"
+
+
+def test_evpn_vlan_update_excludes_index():
+    body = {
+        "rd": "65000:3999",
+        "export_route_targets": ["65000:3999"],
+        "import_route_targets": ["65000:3999"],
+    }
+    session = make_session(get_body=body)
+    ev = EvpnVlan(session, 3999)
+    ev.get(selector="writable")
+    assert "vlan" not in ev.config_attrs
+    assert ev.update() is False
+    ev.rd = "65000:3998"
+    assert ev.update() is True
+
+
+def test_evpn_vlan_get_all():
+    body = {
+        "204": "/rest/v10.09/system/evpn/evpn_vlans/204",
+        "205": "/rest/v10.09/system/evpn/evpn_vlans/205",
+    }
+    session = make_session(get_body=body)
+    collection = EvpnVlan.get_all(session)
+    assert set(collection.keys()) == {"204", "205"}
+    assert all(isinstance(v, EvpnVlan) for v in collection.values())


### PR DESCRIPTION
## Description

Adds two new resource modules for managing **EVPN (Ethernet VPN)** configuration on AOS-CX devices:

- **`Evpn`** — singleton resource at `system/evpn` for the global EVPN settings (ARP/ND suppression, MAC move count/timer, redistribute).
- **`EvpnVlan`** — per-VLAN EVPN settings under `system/evpn/evpn_vlans`, indexed by VLAN ID (route distinguisher, import/export route targets, redistribute).

Both classes follow the standard `PyaoscxModule` lifecycle (`get`/`get_all`/`apply`/`update`/`create`/`delete`) and are registered in `api.get_module()`.

Fixes #58.

## Implementation notes

- The `Evpn` singleton is dispatched like `Vsx` (no index id): `module_class(session, **kwargs)`.
- `EvpnVlan.create()` sends the `vlan` attribute as a **URI reference** to the VLAN resource (`/rest/v<ver>/system/vlans/<id>`), which the REST API requires — the plain VLAN ID is rejected with HTTP 500.
- `EvpnVlan` excludes the `vlan` index from the writable PUT body via `indices`.

## Testing

- Added offline unit tests in `tests/test_evpn.py` (9 tests, mocked session).
- Live-verified on an Aruba CX 6300 (FL.10.17.1001, REST v10.09):
  - `Evpn`: read, modify + restore of `mac_move_timer`, idempotent no-op.
  - `EvpnVlan`: create on a test VLAN (with `rd` + route targets), read-back, update `rd`, idempotent no-op, delete; `get_all` returns the collection.

## Checklist

- [x] `flake8` / `black` (line length 79) clean
- [x] Unit tests pass
- [x] Live-tested against a switch
- [x] DCO sign-off

Companion collection PR: aruba/aoscx-ansible-collection#150
