### PR TITLE
Add Mirror and MirrorEndpoint resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -167,6 +167,8 @@ class API(ABC):
             "QueueProfileEntry": "queue_profile_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
+            "Mirror": "mirror",
+            "MirrorEndpoint": "mirror_endpoint",
         }
         if name not in module_names:
             raise ParameterError(

--- a/pyaoscx/mirror.py
+++ b/pyaoscx/mirror.py
@@ -1,0 +1,240 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class Mirror(PyaoscxModule):
+    """
+    Provide configuration management for mirror (traffic monitoring) sessions
+        on AOS-CX devices. These resources live under system/mirrors and are
+        indexed by the numeric session id.
+    """
+
+    base_uri = "system/mirrors"
+    resource_uri_name = "mirrors"
+
+    indices = ["id"]
+
+    # Writable attributes that reference Port (Interface) resources. They are
+    # stored as lists of Interface objects and serialized to the API's
+    # {name: uri} reference form.
+    port_reference_attrs = (
+        "output_port",
+        "select_src_port",
+        "select_dst_port",
+    )
+    # Writable attributes that reference VLAN resources.
+    vlan_reference_attrs = (
+        "select_rx_vlan",
+        "select_tx_vlan",
+    )
+
+    def __init__(self, session, id, **kwargs):
+        self.session = session
+        # The index is the numeric session id
+        self.id = id
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        # Set arguments needed for correct creation
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.id)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a mirror session and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        # The REST API returns references as {name: uri} dictionaries; turn
+        # them into lists of pyaoscx objects so they are easy to manipulate.
+        self._references_to_objects()
+        self.materialized = True
+        return True
+
+    def _references_to_objects(self):
+        """
+        Convert the {name: uri} reference dictionaries returned by the API
+            into lists of materialized pyaoscx objects.
+        """
+        for attr in self.port_reference_attrs:
+            value = getattr(self, attr, None)
+            if isinstance(value, dict):
+                ports = [
+                    self.session.api.get_module(self.session, "Interface", n)
+                    for n in value
+                ]
+                setattr(self, attr, ports)
+        for attr in self.vlan_reference_attrs:
+            value = getattr(self, attr, None)
+            if isinstance(value, dict):
+                vlans = [
+                    self.session.api.get_module(self.session, "Vlan", int(n))
+                    for n in value
+                ]
+                setattr(self, attr, vlans)
+
+    def _build_data(self):
+        """
+        Build the request body, serializing reference attributes into the
+            API's {name: uri} form.
+
+        :return: Dictionary ready to be sent to the switch.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        for attr in self.port_reference_attrs + self.vlan_reference_attrs:
+            if attr in data:
+                formatted = {}
+                for obj in getattr(self, attr) or []:
+                    formatted.update(obj.get_info_format())
+                data[attr] = formatted
+        return data
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all mirror sessions and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing session ids as keys and Mirror objects
+            as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for uri in data.values():
+            session_id, mirror = cls.from_uri(session, uri)
+            collection[session_id] = mirror
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a Mirror object given a mirror session URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the session id and the Mirror object.
+        """
+        # The URI ends with the session id, e.g. system/mirrors/1
+        session_id = uri.rstrip("/").split("/")[-1]
+        mirror = cls(session, int(session_id))
+        return session_id, mirror
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update a mirror session.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing mirror session.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = self._build_data()
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new mirror session using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = self._build_data()
+        # The session id is the index and must be present in the POST body.
+        data["id"] = self.id
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the mirror session.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific mirror session URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.id,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/mirror_endpoint.py
+++ b/pyaoscx/mirror_endpoint.py
@@ -1,0 +1,222 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class MirrorEndpoint(PyaoscxModule):
+    """
+    Provide configuration management for remote mirror endpoints (ERSPAN
+        tunnel destinations) on AOS-CX devices. These resources live under
+        system/mirror_endpoints and are indexed by name.
+    """
+
+    base_uri = "system/mirror_endpoints"
+    resource_uri_name = "mirror_endpoints"
+
+    indices = ["name"]
+
+    # Writable attributes that reference Port (Interface) resources, stored
+    # as lists of Interface objects and serialized to the API's {name: uri}
+    # reference form.
+    port_reference_attrs = ("output_port",)
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        # The index is the endpoint name
+        self.name = name
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        # Set arguments needed for correct creation
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a mirror endpoint and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        # The REST API returns references as {name: uri} dictionaries; turn
+        # them into lists of pyaoscx objects so they are easy to manipulate.
+        self._references_to_objects()
+        self.materialized = True
+        return True
+
+    def _references_to_objects(self):
+        """
+        Convert the {name: uri} reference dictionaries returned by the API
+            into lists of materialized pyaoscx objects.
+        """
+        for attr in self.port_reference_attrs:
+            value = getattr(self, attr, None)
+            if isinstance(value, dict):
+                ports = [
+                    self.session.api.get_module(self.session, "Interface", n)
+                    for n in value
+                ]
+                setattr(self, attr, ports)
+
+    def _build_data(self):
+        """
+        Build the request body, serializing reference attributes into the
+            API's {name: uri} form.
+
+        :return: Dictionary ready to be sent to the switch.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        for attr in self.port_reference_attrs:
+            if attr in data:
+                formatted = {}
+                for obj in getattr(self, attr) or []:
+                    formatted.update(obj.get_info_format())
+                data[attr] = formatted
+        return data
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all mirror endpoints and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing endpoint names as keys and
+            MirrorEndpoint objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a MirrorEndpoint object given a mirror endpoint URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the endpoint name and the MirrorEndpoint object.
+        """
+        # The URI ends with the endpoint name, e.g. system/mirror_endpoints/e1
+        name = uri.rstrip("/").split("/")[-1]
+        endpoint = cls(session, name)
+        return name, endpoint
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update a mirror endpoint.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing mirror endpoint.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = self._build_data()
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new mirror endpoint using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = self._build_data()
+        # The endpoint name is the index and must be present in the POST body.
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the mirror endpoint.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific mirror endpoint URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,0 +1,230 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the Mirror and MirrorEndpoint pyaoscx resource
+modules. The pyaoscx Session is mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.mirror import Mirror
+from pyaoscx.mirror_endpoint import MirrorEndpoint
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def fake_port(name):
+    port = MagicMock()
+    port.name = name
+    uri = "/rest/v10.09/system/interfaces/{0}".format(name.replace("/", "%2F"))
+    port.get_info_format.return_value = {name: uri}
+    return port
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["configuration", "writable"]
+    api.valid_depth = lambda depth: True
+    session.resource_prefix = "/rest/v10.09/"
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Interface":
+            return fake_port(index)
+        if module == "Vlan":
+            vlan = MagicMock()
+            vlan.name = str(index)
+            uri = "/rest/v10.09/system/vlans/{0}".format(index)
+            vlan.get_info_format.return_value = {str(index): uri}
+            return vlan
+        raise AssertionError("unexpected module {0}".format(module))
+
+    api.get_module.side_effect = get_module
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# Mirror
+# --------------------------------------------------------------------------
+def test_mirror_path():
+    session = make_session()
+    mirror = Mirror(session, 5)
+    assert mirror.path == "system/mirrors/5"
+    assert mirror.id == 5
+
+
+def test_mirror_get_converts_references():
+    body = {
+        "active": False,
+        "session_type": "port",
+        "select_src_port": {
+            "1/1/27": "/rest/v10.09/system/interfaces/1%2F1%2F27"
+        },
+        "output_port": {"1/1/28": "/rest/v10.09/system/interfaces/1%2F1%2F28"},
+        "select_dst_port": {},
+        "select_rx_vlan": {},
+        "select_tx_vlan": {},
+    }
+    session = make_session(get_body=body)
+    mirror = Mirror(session, 5)
+    mirror.get(selector="writable")
+    assert [p.name for p in mirror.select_src_port] == ["1/1/27"]
+    assert [p.name for p in mirror.output_port] == ["1/1/28"]
+    assert mirror.select_dst_port == []
+
+
+def test_mirror_create_sends_id_and_refs():
+    session = make_session()
+    src = fake_port("1/1/27")
+    out = fake_port("1/1/28")
+    mirror = Mirror(
+        session,
+        99,
+        session_type="port",
+        active=False,
+        select_src_port=[src],
+        output_port=[out],
+    )
+    mirror.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["data"]["id"] == 99
+    assert post["data"]["select_src_port"] == {
+        "1/1/27": "/rest/v10.09/system/interfaces/1%2F1%2F27"
+    }
+    assert post["data"]["output_port"] == {
+        "1/1/28": "/rest/v10.09/system/interfaces/1%2F1%2F28"
+    }
+
+
+def test_mirror_update_idempotent():
+    body = {
+        "active": False,
+        "comment": "x",
+        "session_type": "port",
+        "select_src_port": {
+            "1/1/27": "/rest/v10.09/system/interfaces/1%2F1%2F27"
+        },
+        "output_port": {},
+        "select_dst_port": {},
+        "select_rx_vlan": {},
+        "select_tx_vlan": {},
+    }
+    session = make_session(get_body=body)
+    mirror = Mirror(session, 5)
+    mirror.get(selector="writable")
+    assert mirror.update() is False
+    mirror.comment = "y"
+    assert mirror.update() is True
+
+
+def test_mirror_from_uri():
+    session = make_session()
+    session_id, mirror = Mirror.from_uri(session, "system/mirrors/7")
+    assert session_id == "7"
+    assert mirror.id == 7
+
+
+def test_mirror_get_all():
+    body = {"1": "/rest/v10.09/system/mirrors/1"}
+    session = make_session(get_body=body)
+    collection = Mirror.get_all(session)
+    assert set(collection.keys()) == {"1"}
+    assert isinstance(collection["1"], Mirror)
+
+
+# --------------------------------------------------------------------------
+# MirrorEndpoint
+# --------------------------------------------------------------------------
+def test_endpoint_path():
+    session = make_session()
+    ep = MirrorEndpoint(session, "e1")
+    assert ep.path == "system/mirror_endpoints/e1"
+    assert ep.name == "e1"
+
+
+def test_endpoint_get_converts_references():
+    body = {
+        "admin": "down",
+        "comment": None,
+        "output_port": {"1/1/27": "/rest/v10.09/system/interfaces/1%2F1%2F27"},
+        "tunnel": {},
+    }
+    session = make_session(get_body=body)
+    ep = MirrorEndpoint(session, "e1")
+    ep.get(selector="writable")
+    assert [p.name for p in ep.output_port] == ["1/1/27"]
+
+
+def test_endpoint_create_sends_name_and_refs():
+    session = make_session()
+    out = fake_port("1/1/27")
+    ep = MirrorEndpoint(
+        session,
+        "ansible_ep",
+        admin="down",
+        output_port=[out],
+        tunnel={"id": 100},
+    )
+    ep.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["data"]["name"] == "ansible_ep"
+    assert post["data"]["output_port"] == {
+        "1/1/27": "/rest/v10.09/system/interfaces/1%2F1%2F27"
+    }
+    assert post["data"]["tunnel"] == {"id": 100}
+
+
+def test_endpoint_update_idempotent():
+    body = {
+        "admin": "down",
+        "comment": "x",
+        "output_port": {},
+        "tunnel": {},
+    }
+    session = make_session(get_body=body)
+    ep = MirrorEndpoint(session, "e1")
+    ep.get(selector="writable")
+    assert ep.update() is False
+    ep.admin = "up"
+    assert ep.update() is True
+
+
+def test_endpoint_get_all():
+    body = {"e1": "/rest/v10.09/system/mirror_endpoints/e1"}
+    session = make_session(get_body=body)
+    collection = MirrorEndpoint.get_all(session)
+    assert set(collection.keys()) == {"e1"}
+    assert isinstance(collection["e1"], MirrorEndpoint)


### PR DESCRIPTION
## Description

Add port mirroring support to the pyaoscx SDK. Fixes #60.

This introduces two new resource modules:

- **`Mirror`** (`pyaoscx/mirror.py`) — manages `system/mirrors` sessions, indexed by `id`. Supports `session_type`, `active`, `comment`, the `output_port` destination, the `select_src_port`/`select_dst_port` monitored ports and the `select_rx_vlan`/`select_tx_vlan` monitored VLANs. Port and VLAN references are exposed as lists of pyaoscx objects and serialized to the API `{name: uri}` reference form. The `id` is included in the POST body on create.
- **`MirrorEndpoint`** (`pyaoscx/mirror_endpoint.py`) — manages `system/mirror_endpoints` remote (ERSPAN) destinations, indexed by `name`. Supports `admin`, `comment`, the `output_port` reference and the `tunnel` object. The `name` is included in the POST body on create.

Both classes are registered in the API module-name map (`pyaoscx/api.py`).

## How it was tested

- Offline unit tests (`tests/test_mirror.py`, 11 tests, mocked session) covering path building, reference (de)serialization, create body contents, idempotent updates, `from_uri` parsing and `get_all` collection parsing.
- Live verification against an AOS-CX 6300 (FL.10.17.1001, REST v10.09): full create / read / idempotent no-op / update / reference change / delete lifecycle for both resources, confirming idempotency and correct `{name: uri}` reference round-tripping.

## Checklist

- [x] Apache-2.0 license headers
- [x] Commit signed off (DCO)
- [x] Consistent with existing `PyaoscxModule` resources
- [x] Unit tests added

Companion collection PR: aruba/aoscx-ansible-collection#147
