### PR TITLE
Add sFlow (SFlow, SFlowCollector) resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "SFlow": "sflow",
+            "SFlowCollector": "sflow_collector",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/sflow.py
+++ b/pyaoscx/sflow.py
@@ -1,0 +1,184 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class SFlow(PyaoscxModule):
+    """
+    Provide configuration management for sFlow (traffic sampling) instances on
+        AOS-CX devices. These resources live under system/sflows and are
+        indexed by name.
+    """
+
+    base_uri = "system/sflows"
+    resource_uri_name = "sflows"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        # The index is the sFlow instance name
+        self.name = name
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        # Set arguments needed for correct creation
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an sFlow instance and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all sFlow instances and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing instance names as keys and SFlow
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an SFlow object given an sFlow URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the instance name and the SFlow object.
+        """
+        # The URI ends with the instance name, e.g. system/sflows/global
+        name = uri.rstrip("/").split("/")[-1]
+        sflow = cls(session, name)
+        return name, sflow
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an sFlow instance.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing sFlow instance.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new sFlow instance using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The instance name is the index and must be present in the POST body.
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the sFlow instance.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific sFlow instance URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/sflow_collector.py
+++ b/pyaoscx/sflow_collector.py
@@ -1,0 +1,210 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class SFlowCollector(PyaoscxModule):
+    """
+    Provide configuration management for sFlow collectors on AOS-CX devices.
+        A collector is a nested resource under an sFlow instance
+        (system/sflows/{name}/collectors) and is identified by the compound
+        index (vrf, ip_address, udp_port). The collector has no writable
+        attributes beyond its index, so it only supports create and delete.
+    """
+
+    resource_uri_name = "collectors"
+
+    indices = ["vrf", "ip_address", "udp_port"]
+
+    def __init__(
+        self, session, vrf, ip_address, udp_port, parent_sflow, **kwargs
+    ):
+        self.session = session
+        # Compound index: a Vrf object, an IP string and a UDP port integer
+        self.vrf = vrf
+        self.ip_address = ip_address
+        self.udp_port = udp_port
+        # Parent sFlow instance the collector belongs to
+        self.__parent_sflow = parent_sflow
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.base_uri = "{0}/collectors".format(parent_sflow.path)
+        self.path = "{0}/{1}".format(self.base_uri, self._index_key())
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    def _index_key(self):
+        """
+        Build the compound index key used in the resource URI.
+
+        :return: String "vrf,ip_address,udp_port".
+        """
+        sep = self.session.api.compound_index_separator
+        return sep.join([self.vrf.name, self.ip_address, str(self.udp_port)])
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to confirm the collector exists. The collector has
+            no writable attributes beyond its index.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, parent_sflow):
+        """
+        Perform a GET call to retrieve all collectors of a given sFlow
+            instance and create a dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :param parent_sflow: SFlow object the collectors belong to.
+        :return: Dictionary containing the compound index keys as keys and
+            SFlowCollector objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = "{0}/collectors".format(parent_sflow.path)
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for key, value in data.items():
+            collection[key] = cls.from_uri(session, value, parent_sflow)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri, parent_sflow):
+        """
+        Create an SFlowCollector object given a collector URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :param parent_sflow: SFlow object the collector belongs to.
+        :return: Tuple with the compound index key and the SFlowCollector.
+        """
+        key = uri.rstrip("/").split("/")[-1]
+        sep = session.api.compound_index_separator
+        vrf_name, ip_address, udp_port = key.split(sep)
+        vrf = session.api.get_module(session, "Vrf", vrf_name)
+        collector = cls(session, vrf, ip_address, int(udp_port), parent_sflow)
+        return key, collector
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to create the collector if it does not exist.
+
+        :return: True if the object was created.
+        """
+        if self.materialized:
+            return False
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        A collector has no writable attributes beyond its index, so there is
+            nothing to update. Present to satisfy the base class interface.
+
+        :return: Always False (never modified by an update).
+        """
+        return False
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new collector. The compound index
+            (vrf as a URI reference, ip_address and udp_port) makes up the
+            POST body.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = {
+            "vrf": "{0}system/vrfs/{1}".format(
+                self.session.resource_prefix, self.vrf.name
+            ),
+            "ip_address": self.ip_address,
+            "udp_port": self.udp_port,
+        }
+        self._send_data(self.base_uri, data, "POST", "Adding")
+        self.materialized = True
+        self.__modified = True
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the collector.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific collector URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self._index_key(),
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -1,0 +1,226 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the SFlow and SFlowCollector pyaoscx resource
+modules. The pyaoscx Session is mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.sflow import SFlow
+from pyaoscx.sflow_collector import SFlowCollector
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def fake_vrf(name):
+    vrf = MagicMock()
+    vrf.name = name
+    return vrf
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["configuration", "writable"]
+    api.valid_depth = lambda depth: True
+    api.compound_index_separator = ","
+    session.resource_prefix = "/rest/v10.09/"
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Vrf":
+            return fake_vrf(index)
+        raise AssertionError("unexpected module {0}".format(module))
+
+    api.get_module.side_effect = get_module
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# SFlow
+# --------------------------------------------------------------------------
+def test_sflow_path():
+    session = make_session()
+    sflow = SFlow(session, "global")
+    assert sflow.path == "system/sflows/global"
+    assert sflow.name == "global"
+
+
+def test_sflow_from_uri():
+    session = make_session()
+    name, sflow = SFlow.from_uri(session, "/rest/v10.09/system/sflows/global")
+    assert name == "global"
+    assert sflow.name == "global"
+    assert sflow.path == "system/sflows/global"
+
+
+def test_sflow_create_sends_name_and_attrs():
+    session = make_session()
+    sflow = SFlow(
+        session,
+        "ansible-test",
+        enabled=False,
+        mode="both",
+        polling=20,
+        sampling=2048,
+    )
+    sflow.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["path"] == "system/sflows"
+    assert post["data"]["name"] == "ansible-test"
+    assert post["data"]["mode"] == "both"
+    assert post["data"]["polling"] == 20
+
+
+def test_sflow_update_idempotent():
+    body = {
+        "enabled": False,
+        "mode": "both",
+        "polling": 20,
+        "sampling": 2048,
+    }
+    session = make_session(get_body=body)
+    sflow = SFlow(session, "ansible-test")
+    sflow.get(selector="writable")
+    # No change applied, an update must be a no-op (no PUT request made).
+    assert sflow.update() is False
+    assert not any(c["method"] == "PUT" for c in session.calls)
+
+
+def test_sflow_update_sends_put_on_change():
+    body = {
+        "enabled": False,
+        "mode": "both",
+        "polling": 20,
+        "sampling": 2048,
+    }
+    session = make_session(get_body=body)
+    sflow = SFlow(session, "ansible-test")
+    sflow.get(selector="writable")
+    sflow.polling = 25
+    assert sflow.update() is True
+    put = next(c for c in session.calls if c["method"] == "PUT")
+    assert put["data"]["polling"] == 25
+
+
+def test_sflow_get_all():
+    body = {"global": "/rest/v10.09/system/sflows/global"}
+    session = make_session(get_body=body)
+    result = SFlow.get_all(session)
+    assert list(result.keys()) == ["global"]
+    assert result["global"].name == "global"
+
+
+def test_sflow_delete():
+    session = make_session()
+    sflow = SFlow(session, "ansible-test")
+    sflow.delete()
+    delete = next(c for c in session.calls if c["method"] == "DELETE")
+    assert delete["path"] == "system/sflows/ansible-test"
+
+
+# --------------------------------------------------------------------------
+# SFlowCollector
+# --------------------------------------------------------------------------
+def test_collector_path():
+    session = make_session()
+    parent = SFlow(session, "global")
+    vrf = fake_vrf("default")
+    collector = SFlowCollector(session, vrf, "10.0.0.50", 6343, parent)
+    assert collector.base_uri == "system/sflows/global/collectors"
+    assert collector.path == (
+        "system/sflows/global/collectors/default,10.0.0.50,6343"
+    )
+
+
+def test_collector_create_sends_uri_ref():
+    session = make_session()
+    parent = SFlow(session, "global")
+    vrf = fake_vrf("default")
+    collector = SFlowCollector(session, vrf, "10.0.0.50", 6343, parent)
+    collector.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["path"] == "system/sflows/global/collectors"
+    assert post["data"]["vrf"] == "/rest/v10.09/system/vrfs/default"
+    assert post["data"]["ip_address"] == "10.0.0.50"
+    assert post["data"]["udp_port"] == 6343
+
+
+def test_collector_update_noop():
+    session = make_session()
+    parent = SFlow(session, "global")
+    vrf = fake_vrf("default")
+    collector = SFlowCollector(session, vrf, "10.0.0.50", 6343, parent)
+    assert collector.update() is False
+
+
+def test_collector_from_uri():
+    session = make_session()
+    parent = SFlow(session, "global")
+    uri = (
+        "/rest/v10.09/system/sflows/global/collectors/"
+        "default,10.0.0.50,6343"
+    )
+    key, collector = SFlowCollector.from_uri(session, uri, parent)
+    assert key == "default,10.0.0.50,6343"
+    assert collector.vrf.name == "default"
+    assert collector.ip_address == "10.0.0.50"
+    assert collector.udp_port == 6343
+
+
+def test_collector_get_all():
+    body = {
+        "default,10.0.0.50,6343": (
+            "/rest/v10.09/system/sflows/global/collectors/"
+            "default,10.0.0.50,6343"
+        )
+    }
+    session = make_session(get_body=body)
+    parent = SFlow(session, "global")
+    result = SFlowCollector.get_all(session, parent)
+    assert list(result.keys()) == ["default,10.0.0.50,6343"]
+
+
+def test_collector_delete():
+    session = make_session()
+    parent = SFlow(session, "global")
+    vrf = fake_vrf("default")
+    collector = SFlowCollector(session, vrf, "10.0.0.50", 6343, parent)
+    collector.delete()
+    delete = next(c for c in session.calls if c["method"] == "DELETE")
+    assert delete["path"] == (
+        "system/sflows/global/collectors/default,10.0.0.50,6343"
+    )


### PR DESCRIPTION
## Description

Adds sFlow (traffic sampling) support to pyaoscx with two new resource modules.

Fixes #62.

### `SFlow`

Manages `system/sflows` instances, indexed by `name`. Exposes the writable scalar attributes `agent_address`, `enabled`, `header`, `max_datagram`, `mode`, `polling` and `sampling`.

### `SFlowCollector`

Manages the nested `system/sflows/{name}/collectors` resource, identified by the compound index `(vrf, ip_address, udp_port)`. The collector has no writable attributes beyond its index, so it supports create and delete only.

Both classes are registered in the API module map.

## Testing

- Offline unit tests in `tests/test_sflow.py` (13 tests) covering URI building, `from_uri`, create/update/delete request bodies, idempotent update and collection parsing.
- Verified live against an AOS-CX 6300 running FL.10.17.1001 (REST v10.09): full create/update/delete lifecycle for an sFlow instance (all writable scalars) and a collector (create, list, delete), including idempotent no-op updates.

## Checklist

- [x] `black --line-length 79` clean
- [x] `flake8 --max-line-length 79` clean
- [x] Unit tests pass
- [x] Signed-off-by (DCO)

Companion collection PR: aruba/aoscx-ansible-collection#145
