### PR TITLE
Add IPFIX (flow record, exporter, monitor) resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,9 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "IpfixFlowRecord": "ipfix_flow_record",
+            "IpfixFlowExporter": "ipfix_flow_exporter",
+            "IpfixFlowMonitor": "ipfix_flow_monitor",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/ipfix_flow_exporter.py
+++ b/pyaoscx/ipfix_flow_exporter.py
@@ -1,0 +1,184 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class IpfixFlowExporter(PyaoscxModule):
+    """
+    Provide configuration management for IPFIX flow exporters on AOS-CX
+        devices. A flow exporter defines where exported IPFIX flows are sent
+        (a hostname/IP in a VRF, or a Traffic Insight instance) and the
+        transport used. These resources live under system/ipfix_flow_exporters
+        and are indexed by name.
+    """
+
+    base_uri = "system/ipfix_flow_exporters"
+    resource_uri_name = "ipfix_flow_exporters"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        # The index is the flow exporter name
+        self.name = name
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a flow exporter and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all flow exporters and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing exporter names as keys and
+            IpfixFlowExporter objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an IpfixFlowExporter object given a flow exporter URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the exporter name and the IpfixFlowExporter object.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        exporter = cls(session, name)
+        return name, exporter
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update a flow exporter.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing flow exporter.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new flow exporter using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The exporter name is the index and must be present in the POST body.
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the flow exporter.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific flow exporter URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/ipfix_flow_monitor.py
+++ b/pyaoscx/ipfix_flow_monitor.py
@@ -1,0 +1,237 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class IpfixFlowMonitor(PyaoscxModule):
+    """
+    Provide configuration management for IPFIX flow monitors on AOS-CX
+        devices. A flow monitor binds a flow record to one or more flow
+        exporters and controls the flow cache timeouts. These resources live
+        under system/ipfix_flow_monitors and are indexed by name.
+    """
+
+    base_uri = "system/ipfix_flow_monitors"
+    resource_uri_name = "ipfix_flow_monitors"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        # The index is the flow monitor name
+        self.name = name
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a flow monitor and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        # The REST API returns references as {name: uri} dictionaries; turn
+        # them into pyaoscx objects so they are easy to manipulate.
+        self._references_to_objects()
+        self.materialized = True
+        return True
+
+    def _references_to_objects(self):
+        """
+        Convert the {name: uri} reference dictionaries returned by the API
+            into pyaoscx objects: a list of IpfixFlowExporter for "exporter"
+            and a single IpfixFlowRecord for "record".
+        """
+        exporter = getattr(self, "exporter", None)
+        if isinstance(exporter, dict):
+            setattr(
+                self,
+                "exporter",
+                [
+                    self.session.api.get_module(
+                        self.session, "IpfixFlowExporter", n
+                    )
+                    for n in exporter
+                ],
+            )
+        record = getattr(self, "record", None)
+        if isinstance(record, dict):
+            names = list(record)
+            setattr(
+                self,
+                "record",
+                (
+                    self.session.api.get_module(
+                        self.session, "IpfixFlowRecord", names[0]
+                    )
+                    if names
+                    else None
+                ),
+            )
+
+    def _build_data(self):
+        """
+        Build the request body, serializing reference attributes into the
+            API's {name: uri} form.
+
+        :return: Dictionary ready to be sent to the switch.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        if "exporter" in data:
+            formatted = {}
+            for obj in getattr(self, "exporter") or []:
+                formatted.update(obj.get_info_format())
+            data["exporter"] = formatted
+        if "record" in data:
+            record = getattr(self, "record")
+            data["record"] = record.get_info_format() if record else {}
+        return data
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all flow monitors and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing monitor names as keys and
+            IpfixFlowMonitor objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an IpfixFlowMonitor object given a flow monitor URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the monitor name and the IpfixFlowMonitor object.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        monitor = cls(session, name)
+        return name, monitor
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update a flow monitor.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing flow monitor.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = self._build_data()
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new flow monitor using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = self._build_data()
+        # The monitor name is the index and must be present in the POST body.
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the flow monitor.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific flow monitor URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/ipfix_flow_record.py
+++ b/pyaoscx/ipfix_flow_record.py
@@ -1,0 +1,183 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class IpfixFlowRecord(PyaoscxModule):
+    """
+    Provide configuration management for IPFIX flow records on AOS-CX devices.
+        A flow record defines the key fields (match) and non-key fields
+        (collect) included in exported IPFIX flows. These resources live under
+        system/ipfix_flow_records and are indexed by name.
+    """
+
+    base_uri = "system/ipfix_flow_records"
+    resource_uri_name = "ipfix_flow_records"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        # The index is the flow record name
+        self.name = name
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a flow record and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all flow records and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing record names as keys and IpfixFlowRecord
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an IpfixFlowRecord object given a flow record URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the record name and the IpfixFlowRecord object.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        record = cls(session, name)
+        return name, record
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update a flow record.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing flow record.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new flow record using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The record name is the index and must be present in the POST body.
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the flow record.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific flow record URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/rest/v10_13/api.py
+++ b/pyaoscx/rest/v10_13/api.py
@@ -1,0 +1,39 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_13(API):
+    """
+    Represents a REST API Version 10.13. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2023, 10, 31)
+        self.version = "10.13"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_13/interface.py
+++ b/pyaoscx/rest/v10_13/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.13.
+    """
+
+    pass

--- a/tests/test_ipfix.py
+++ b/tests/test_ipfix.py
@@ -1,0 +1,216 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the IpfixFlowRecord, IpfixFlowExporter and
+IpfixFlowMonitor pyaoscx resource modules. The pyaoscx Session is mocked, so
+no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.ipfix_flow_record import IpfixFlowRecord
+from pyaoscx.ipfix_flow_exporter import IpfixFlowExporter
+from pyaoscx.ipfix_flow_monitor import IpfixFlowMonitor
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def fake_ref(name, kind):
+    obj = MagicMock()
+    obj.name = name
+    uri = "/rest/v10.13/system/{0}/{1}".format(kind, name)
+    obj.get_info_format.return_value = {name: uri}
+    return obj
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["configuration", "writable"]
+    api.valid_depth = lambda depth: True
+    session.resource_prefix = "/rest/v10.13/"
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "IpfixFlowExporter":
+            return fake_ref(index, "ipfix_flow_exporters")
+        if module == "IpfixFlowRecord":
+            return fake_ref(index, "ipfix_flow_records")
+        raise AssertionError("unexpected module {0}".format(module))
+
+    api.get_module.side_effect = get_module
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# IpfixFlowRecord
+# --------------------------------------------------------------------------
+def test_record_path():
+    session = make_session()
+    record = IpfixFlowRecord(session, "r1")
+    assert record.path == "system/ipfix_flow_records/r1"
+    assert record.name == "r1"
+
+
+def test_record_create_sends_name_and_dicts():
+    session = make_session()
+    record = IpfixFlowRecord(
+        session,
+        "r1",
+        description="d",
+        match={"ipv4_source_address": True},
+        collect={"counter_bytes": True},
+    )
+    record.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["path"] == "system/ipfix_flow_records"
+    assert post["data"]["name"] == "r1"
+    assert post["data"]["match"] == {"ipv4_source_address": True}
+    assert post["data"]["collect"] == {"counter_bytes": True}
+
+
+def test_record_update_idempotent():
+    body = {"description": "d", "match": {"ipv4_version": True}, "collect": {}}
+    session = make_session(get_body=body)
+    record = IpfixFlowRecord(session, "r1")
+    record.get(selector="writable")
+    assert record.update() is False
+    assert not any(c["method"] == "PUT" for c in session.calls)
+
+
+def test_record_get_all():
+    body = {"app-vis": "/rest/v10.13/system/ipfix_flow_records/app-vis"}
+    session = make_session(get_body=body)
+    result = IpfixFlowRecord.get_all(session)
+    assert list(result.keys()) == ["app-vis"]
+
+
+# --------------------------------------------------------------------------
+# IpfixFlowExporter
+# --------------------------------------------------------------------------
+def test_exporter_path():
+    session = make_session()
+    exporter = IpfixFlowExporter(session, "e1")
+    assert exporter.path == "system/ipfix_flow_exporters/e1"
+
+
+def test_exporter_create_sends_name_and_attrs():
+    session = make_session()
+    exporter = IpfixFlowExporter(
+        session,
+        "e1",
+        description="d",
+        destination_type="hostname-or-ip-addr",
+        destination_hostname_or_ip_addr={
+            "10.0.0.50": "/rest/v10.13/system/vrfs/default"
+        },
+        template_data_timeout=60,
+        transport={"port": 2055, "protocol": "udp"},
+    )
+    exporter.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["path"] == "system/ipfix_flow_exporters"
+    assert post["data"]["name"] == "e1"
+    assert post["data"]["destination_type"] == "hostname-or-ip-addr"
+    assert post["data"]["transport"] == {"port": 2055, "protocol": "udp"}
+
+
+def test_exporter_delete():
+    session = make_session()
+    exporter = IpfixFlowExporter(session, "e1")
+    exporter.delete()
+    delete = next(c for c in session.calls if c["method"] == "DELETE")
+    assert delete["path"] == "system/ipfix_flow_exporters/e1"
+
+
+# --------------------------------------------------------------------------
+# IpfixFlowMonitor
+# --------------------------------------------------------------------------
+def test_monitor_get_converts_references():
+    body = {
+        "cache_timeout_active": 60,
+        "cache_timeout_inactive": 40,
+        "description": "d",
+        "exporter": {"e1": "/rest/v10.13/system/ipfix_flow_exporters/e1"},
+        "record": {"r1": "/rest/v10.13/system/ipfix_flow_records/r1"},
+    }
+    session = make_session(get_body=body)
+    monitor = IpfixFlowMonitor(session, "m1")
+    monitor.get(selector="writable")
+    assert [e.name for e in monitor.exporter] == ["e1"]
+    assert monitor.record.name == "r1"
+
+
+def test_monitor_create_sends_refs():
+    session = make_session()
+    exporter = fake_ref("e1", "ipfix_flow_exporters")
+    record = fake_ref("r1", "ipfix_flow_records")
+    monitor = IpfixFlowMonitor(
+        session,
+        "m1",
+        cache_timeout_active=60,
+        exporter=[exporter],
+        record=record,
+    )
+    monitor.create()
+    post = next(c for c in session.calls if c["method"] == "POST")
+    assert post["data"]["name"] == "m1"
+    assert post["data"]["exporter"] == {
+        "e1": "/rest/v10.13/system/ipfix_flow_exporters/e1"
+    }
+    assert post["data"]["record"] == {
+        "r1": "/rest/v10.13/system/ipfix_flow_records/r1"
+    }
+
+
+def test_monitor_update_idempotent():
+    body = {
+        "cache_timeout_active": 60,
+        "description": "d",
+        "exporter": {"e1": "/rest/v10.13/system/ipfix_flow_exporters/e1"},
+        "record": {"r1": "/rest/v10.13/system/ipfix_flow_records/r1"},
+    }
+    session = make_session(get_body=body)
+    monitor = IpfixFlowMonitor(session, "m1")
+    monitor.get(selector="writable")
+    assert monitor.update() is False
+    assert not any(c["method"] == "PUT" for c in session.calls)
+
+
+def test_monitor_get_all():
+    body = {"app-vis": "/rest/v10.13/system/ipfix_flow_monitors/app-vis"}
+    session = make_session(get_body=body)
+    result = IpfixFlowMonitor.get_all(session)
+    assert list(result.keys()) == ["app-vis"]


### PR DESCRIPTION
## Description

Adds IPFIX (flow telemetry) support to pyaoscx with three new resource modules, plus a `v10.13` API version module.

Fixes #64.

### `IpfixFlowRecord`

Manages `system/ipfix_flow_records`, indexed by `name`. Exposes the `description` scalar and the `match` (key fields) / `collect` (non-key fields) boolean maps.

### `IpfixFlowExporter`

Manages `system/ipfix_flow_exporters`, indexed by `name`. Exposes `description`, `destination_type` (hostname-or-ip-addr / traffic-insight), `destination_hostname_or_ip_addr` (a VRF reference keyed by the destination host), `destination_traffic_insight`, `template_data_timeout` and the `transport` object (port + protocol).

### `IpfixFlowMonitor`

Manages `system/ipfix_flow_monitors`, indexed by `name`. Binds a flow record and one or more flow exporters, and controls the flow cache timeouts. The `exporter` (list) and `record` (single) reference fields are exchanged with the API as `{name: uri}` maps and converted to/from pyaoscx objects on `get()`/build.

### `v10.13` API version

IPFIX resources are only exposed by REST API v10.13 and later, so a `v10_13` API version module is added (mirroring `v10_09`) to allow opening a session at that version.

## Testing

- Offline unit tests in `tests/test_ipfix.py` (11 tests) covering URI building, create bodies, reference conversion, idempotent update and collection parsing.
- Verified live against an AOS-CX 6300 running FL.10.17.1001 (REST v10.13): full create/update/delete lifecycle for a record, an exporter and a monitor that binds them, including reference round-tripping and idempotent no-op updates. The production `app-vis` IPFIX configuration was left untouched.

## Checklist

- [x] `black --line-length 79` clean
- [x] `flake8 --max-line-length 79` clean
- [x] Unit tests pass
- [x] Signed-off-by (DCO)

Companion collection PR: aruba/aoscx-ansible-collection#159
