### PR TITLE
Add Traffic Insight resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "TrafficInsight": "traffic_insight",
+            "TrafficInsightMonitor": "traffic_insight_monitor",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/rest/v10_13/api.py
+++ b/pyaoscx/rest/v10_13/api.py
@@ -1,0 +1,39 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_13(API):
+    """
+    Represents a REST API Version 10.13. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2023, 10, 31)
+        self.version = "10.13"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_13/interface.py
+++ b/pyaoscx/rest/v10_13/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.13.
+    """
+
+    pass

--- a/pyaoscx/traffic_insight.py
+++ b/pyaoscx/traffic_insight.py
@@ -1,0 +1,184 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class TrafficInsight(PyaoscxModule):
+    """
+    Provide configuration management for Traffic Insight instances on AOS-CX
+        devices. A Traffic Insight instance generates insights from a sample
+        or flow collection protocol (for example IPFIX). These resources live
+        under system/traffic_insights and are indexed by name.
+    """
+
+    base_uri = "system/traffic_insights"
+    resource_uri_name = "traffic_insights"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, **kwargs):
+        self.session = session
+        # The index is the Traffic Insight instance name
+        self.name = name
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Traffic Insight instance and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Traffic Insight instances and create
+            a dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing instance names as keys and
+            TrafficInsight objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a TrafficInsight object given a Traffic Insight instance URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the instance name and the TrafficInsight object.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        instance = cls(session, name)
+        return name, instance
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update a Traffic Insight instance.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Traffic Insight
+            instance.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Traffic Insight instance using the
+            object's attributes as POST body. Exception is raised if object is
+            unable to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The instance name is the index and must be present in the POST body.
+        data["name"] = self.name
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the Traffic Insight instance.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific Traffic Insight instance URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/traffic_insight_monitor.py
+++ b/pyaoscx/traffic_insight_monitor.py
@@ -1,0 +1,213 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class TrafficInsightMonitor(PyaoscxModule):
+    """
+    Provide configuration management for Traffic Insight monitors on AOS-CX
+        devices. A Traffic Insight monitor defines a monitoring request bound
+        to a Traffic Insight instance. These resources live under
+        system/traffic_insight_monitors and are indexed by the compound key
+        (traffic_insight_instance, monitor_name, monitor_type).
+    """
+
+    base_uri = "system/traffic_insight_monitors"
+    resource_uri_name = "traffic_insight_monitors"
+
+    indices = ["traffic_insight_instance", "monitor_name", "monitor_type"]
+
+    def __init__(
+        self,
+        session,
+        traffic_insight_instance,
+        monitor_name,
+        monitor_type,
+        **kwargs
+    ):
+        self.session = session
+        # The compound index is (instance, monitor_name, monitor_type). The
+        # instance is a TrafficInsight object.
+        self.traffic_insight_instance = traffic_insight_instance
+        self.monitor_name = monitor_name
+        self.monitor_type = monitor_type
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        separator = self.session.api.compound_index_separator
+        self.path = "{0}/{1}{2}{3}{4}{5}".format(
+            self.base_uri,
+            self.traffic_insight_instance.name,
+            separator,
+            self.monitor_name,
+            separator,
+            self.monitor_type,
+        )
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Traffic Insight monitor and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Traffic Insight monitors and create
+            a dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing the compound index as keys and
+            TrafficInsightMonitor objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for index, uri in data.items():
+            collection[index] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a TrafficInsightMonitor object given a monitor URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the compound index and the TrafficInsightMonitor
+            object.
+        """
+        index = uri.rstrip("/").split("/")[-1]
+        separator = session.api.compound_index_separator
+        instance_name, monitor_name, monitor_type = index.split(separator)
+        instance = session.api.get_module(
+            session, "TrafficInsight", instance_name
+        )
+        monitor = cls(session, instance, monitor_name, monitor_type)
+        return index, monitor
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update a Traffic Insight monitor.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Traffic Insight
+            monitor.
+
+        :return: True if object was modified and a PUT request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Traffic Insight monitor using the
+            object's attributes as POST body. Exception is raised if object is
+            unable to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The compound index fields must be present in the POST body. The
+        # instance is sent as a reference.
+        data["traffic_insight_instance"] = (
+            self.traffic_insight_instance.get_info_format()
+        )
+        data["monitor_name"] = self.monitor_name
+        data["monitor_type"] = self.monitor_type
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the Traffic Insight monitor.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific Traffic Insight monitor URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix,
+                self.path,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/tests/test_traffic_insight.py
+++ b/tests/test_traffic_insight.py
@@ -1,0 +1,202 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the TrafficInsight and TrafficInsightMonitor pyaoscx
+resource modules. The pyaoscx Session is mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.traffic_insight import TrafficInsight
+from pyaoscx.traffic_insight_monitor import TrafficInsightMonitor
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def fake_instance(name):
+    obj = MagicMock()
+    obj.name = name
+    uri = "/rest/v10.13/system/traffic_insights/{0}".format(name)
+    obj.get_info_format.return_value = {name: uri}
+    return obj
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["configuration", "writable"]
+    api.valid_depth = lambda depth: True
+    api.compound_index_separator = ","
+    session.resource_prefix = "/rest/v10.13/"
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "TrafficInsight":
+            return fake_instance(index)
+        raise AssertionError("unexpected module {0}".format(module))
+
+    api.get_module.side_effect = get_module
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# TrafficInsight
+# --------------------------------------------------------------------------
+def test_instance_path():
+    session = make_session()
+    instance = TrafficInsight(session, "ti1")
+    assert instance.path == "system/traffic_insights/ti1"
+    assert instance.name == "ti1"
+
+
+def test_instance_create_sends_name_and_attrs():
+    session = make_session()
+    instance = TrafficInsight(session, "ti1", enable=True, source=["ipfix"])
+    instance.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/traffic_insights"
+    assert post["data"]["name"] == "ti1"
+    assert post["data"]["enable"] is True
+    assert post["data"]["source"] == ["ipfix"]
+
+
+def test_instance_update_idempotent():
+    body = {"enable": True, "source": ["ipfix"]}
+    session = make_session(get_body=body)
+    instance = TrafficInsight(session, "ti1")
+    instance.get(selector="writable")
+    # No change -> PUT must not be sent.
+    assert instance.update() is False
+    assert not [c for c in session.calls if c["method"] == "PUT"]
+
+
+def test_instance_update_changed():
+    body = {"enable": True, "source": ["ipfix"]}
+    session = make_session(get_body=body)
+    instance = TrafficInsight(session, "ti1")
+    instance.get(selector="writable")
+    instance.enable = False
+    assert instance.update() is True
+    put = [c for c in session.calls if c["method"] == "PUT"][0]
+    assert put["data"]["enable"] is False
+
+
+def test_instance_get_all():
+    body = {"ti1": "/rest/v10.13/system/traffic_insights/ti1"}
+    session = make_session(get_body=body)
+    result = TrafficInsight.get_all(session)
+    assert "ti1" in result
+    assert isinstance(result["ti1"], TrafficInsight)
+
+
+def test_instance_delete():
+    session = make_session()
+    instance = TrafficInsight(session, "ti1")
+    instance.config_attrs = ["enable", "source"]
+    instance.delete()
+    delete = [c for c in session.calls if c["method"] == "DELETE"][0]
+    assert delete["path"] == "system/traffic_insights/ti1"
+
+
+# --------------------------------------------------------------------------
+# TrafficInsightMonitor
+# --------------------------------------------------------------------------
+def test_monitor_path_compound():
+    session = make_session()
+    instance = fake_instance("ti1")
+    monitor = TrafficInsightMonitor(session, instance, "m1", "topN-flows")
+    assert monitor.path == (
+        "system/traffic_insight_monitors/ti1,m1,topN-flows"
+    )
+
+
+def test_monitor_create_sends_index_and_attrs():
+    session = make_session()
+    instance = fake_instance("ti1")
+    monitor = TrafficInsightMonitor(
+        session,
+        instance,
+        "m1",
+        "topN-flows",
+        group_by="appid",
+        monitor_n_flows=10,
+        running_stats_reset_interval=600,
+    )
+    monitor.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/traffic_insight_monitors"
+    assert post["data"]["monitor_name"] == "m1"
+    assert post["data"]["monitor_type"] == "topN-flows"
+    assert post["data"]["traffic_insight_instance"] == {
+        "ti1": "/rest/v10.13/system/traffic_insights/ti1"
+    }
+    assert post["data"]["group_by"] == "appid"
+    assert post["data"]["monitor_n_flows"] == 10
+
+
+def test_monitor_from_uri():
+    session = make_session()
+    uri = "/rest/v10.13/system/traffic_insight_monitors/" "ti1,m1,topN-flows"
+    index, monitor = TrafficInsightMonitor.from_uri(session, uri)
+    assert index == "ti1,m1,topN-flows"
+    assert monitor.monitor_name == "m1"
+    assert monitor.monitor_type == "topN-flows"
+    assert monitor.traffic_insight_instance.name == "ti1"
+
+
+def test_monitor_update_changed():
+    body = {
+        "filter_by_single_value": {},
+        "group_by": "appid",
+        "monitor_n_flows": 10,
+        "running_stats_reset_interval": 600,
+    }
+    session = make_session(get_body=body)
+    instance = fake_instance("ti1")
+    monitor = TrafficInsightMonitor(session, instance, "m1", "topN-flows")
+    monitor.get(selector="writable")
+    monitor.monitor_n_flows = 15
+    assert monitor.update() is True
+    put = [c for c in session.calls if c["method"] == "PUT"][0]
+    assert put["data"]["monitor_n_flows"] == 15
+
+
+def test_monitor_get_all():
+    key = "ti1,m1,topN-flows"
+    body = {key: ("/rest/v10.13/system/traffic_insight_monitors/" + key)}
+    session = make_session(get_body=body)
+    result = TrafficInsightMonitor.get_all(session)
+    assert key in result
+    assert isinstance(result[key], TrafficInsightMonitor)


### PR DESCRIPTION
## Description

Add two pyaoscx resource modules for the AOS-CX **Traffic Insight** feature:

- `TrafficInsight` (`pyaoscx/traffic_insight.py`) — manages the single
  Traffic Insight instance (`system/traffic_insights`), writable attributes
  `enable` (bool) and `source` (list, items enum `["ipfix"]`), indexed by
  `name`.
- `TrafficInsightMonitor` (`pyaoscx/traffic_insight_monitor.py`) — manages
  monitors attached to an instance (`system/traffic_insight_monitors`) using
  the compound index
  `traffic_insight_instance,monitor_name,monitor_type`. Writable attributes:
  `filter_by_single_value`, `group_by`, `monitor_n_flows`,
  `running_stats_reset_interval`.

Both classes are registered in `pyaoscx/api.py`.

These resources require REST API version 10.13, so the `v10_13` API module
is included as a prerequisite.

Fixes #66

## Note on the v10_13 prerequisite

The `pyaoscx/rest/v10_13/` API module is also introduced by #65 (IPFIX).
The two pull requests share this prerequisite; whichever merges second will
need a trivial rebase to drop the duplicated `v10_13` files.

## Testing

- Added offline unit tests with a mocked session
  (`tests/test_traffic_insight.py`, 11 tests, all passing).
- Verified live against an AOS-CX 6300 (FL.10.17, REST v10.13): create,
  read-back, idempotent update (no-op PUT), attribute update and delete for
  both the instance and its monitors.

```
$ python -m pytest tests/test_traffic_insight.py -q
...........
11 passed
```

## Notes

- On the test switch only a single Traffic Insight instance can exist at a
  time; creating a second instance returns HTTP 500. This is a switch-side
  constraint, not an SDK limitation.

Companion collection PR: aruba/aoscx-ansible-collection#153
