### PR TITLE
Add IP SLA resource modules (sources, responders, track objects)

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,9 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "IpslaSource": "ipsla_source",
+            "IpslaResponder": "ipsla_responder",
+            "IpslaTrackObject": "ipsla_track_object",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/ipsla_responder.py
+++ b/pyaoscx/ipsla_responder.py
@@ -1,0 +1,194 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class IpslaResponder(PyaoscxModule):
+    """
+    Provide configuration management for IP SLA responders on AOS-CX devices.
+        A responder answers IP SLA probes (UDP echo, TCP connect, UDP jitter).
+        These resources live under system/ipsla_responders and are indexed by
+        name. The responder attributes are all set at creation time and cannot
+        be modified afterwards, so the resource only supports create and
+        delete.
+    """
+
+    base_uri = "system/ipsla_responders"
+    resource_uri_name = "ipsla_responders"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, vrf=None, **kwargs):
+        self.session = session
+        # The index is the responder name
+        self.name = name
+        # The VRF is a Vrf object serialized as a URI on creation
+        self.vrf = vrf
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an IP SLA responder and fill
+            the object with the incoming attributes. The configuration
+            selector is used by default because the responder has no writable
+            attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        selector = selector or "configuration"
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all IP SLA responders and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing responder names as keys and
+            IpslaResponder objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an IpslaResponder object given a responder URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the responder name and the IpslaResponder object.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        responder = cls(session, name)
+        return name, responder
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to create the responder if it does not exist.
+
+        :return: True if the object was created.
+        """
+        if self.materialized:
+            return False
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        The responder attributes are immutable, so there is nothing to update.
+            Present to satisfy the base class interface.
+
+        :return: Always False (never modified by an update).
+        """
+        return False
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new IP SLA responder using the
+            object's attributes as POST body. Exception is raised if object is
+            unable to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The responder name is the index and must be present in the POST body.
+        data["name"] = self.name
+        # The VRF is a mandatory reference serialized as a URI.
+        if self.vrf is not None:
+            data["vrf"] = "{0}system/vrfs/{1}".format(
+                self.session.resource_prefix, self.vrf.name
+            )
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the IP SLA responder.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific IP SLA responder URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/ipsla_source.py
+++ b/pyaoscx/ipsla_source.py
@@ -1,0 +1,224 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class IpslaSource(PyaoscxModule):
+    """
+    Provide configuration management for IP SLA sources on AOS-CX devices.
+        An IP SLA source defines a probe (ICMP echo, UDP echo, HTTP, DNS, ...)
+        used to measure network performance. These resources live under
+        system/ipsla_sources and are indexed by name. Updates are applied with
+        a PATCH request because the resource rejects a full PUT.
+    """
+
+    base_uri = "system/ipsla_sources"
+    resource_uri_name = "ipsla_sources"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, vrf=None, **kwargs):
+        self.session = session
+        # The index is the source name
+        self.name = name
+        # The VRF is a Vrf object serialized as a URI on creation
+        self.vrf = vrf
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    def _patch_data(self, data):
+        """
+        Perform a PATCH call to partially update the source. The resource
+            rejects a full PUT, so only the changed attributes are sent.
+
+        :param data: dictionary with the attributes to update.
+        """
+        send_data = json.dumps(data, sort_keys=True, indent=4)
+        # session.request does not support PATCH, so use the underlying
+        # requests.Session object with the fully-qualified resource URI.
+        uri = self.session._build_uri(self.path)
+        try:
+            response = self.session.s.patch(
+                uri, verify=False, data=send_data, proxies=self.session.proxy
+            )
+        except Exception as e:
+            raise ResponseError("PATCH", e)
+        if response.status_code not in (200, 204):
+            raise GenericOperationError(response.text, response.status_code)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an IP SLA source and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all IP SLA sources and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing source names as keys and IpslaSource
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an IpslaSource object given a source URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the source name and the IpslaSource object.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        source = cls(session, name)
+        return name, source
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an IP SLA source.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PATCH call to apply changes to an existing IP SLA source.
+            The name, type and vrf are set at creation and are never sent in
+            an update.
+
+        :return: True if object was modified and a PATCH request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        diff = {
+            key: value
+            for key, value in data.items()
+            if self._original_attributes.get(key) != value
+        }
+        for key in ("name", "type", "vrf"):
+            diff.pop(key, None)
+        if not diff:
+            self.__modified = False
+            return self.__modified
+        self._patch_data(diff)
+        self.__modified = True
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new IP SLA source using the object's
+            attributes as POST body. Exception is raised if object is unable
+            to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The source name is the index and must be present in the POST body.
+        data["name"] = self.name
+        # The VRF is a mandatory reference serialized as a URI.
+        if self.vrf is not None:
+            data["vrf"] = "{0}system/vrfs/{1}".format(
+                self.session.resource_prefix, self.vrf.name
+            )
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the IP SLA source.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific IP SLA source URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/ipsla_track_object.py
+++ b/pyaoscx/ipsla_track_object.py
@@ -1,0 +1,228 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class IpslaTrackObject(PyaoscxModule):
+    """
+    Provide configuration management for IP SLA track objects on AOS-CX
+        devices. A track object follows the state of one or more IP SLA
+        sessions and can be used by other features. These resources live under
+        system/ipsla_track_objects and are indexed by name. The tracked
+        sessions are set at creation time and cannot be modified afterwards;
+        the remaining attributes are updated with a PATCH request.
+    """
+
+    base_uri = "system/ipsla_track_objects"
+    resource_uri_name = "ipsla_track_objects"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, tracked_ipsla_session=None, **kwargs):
+        self.session = session
+        # The index is the track object name
+        self.name = name
+        # List of IpslaSource objects tracked by this object (creation only)
+        self.tracked_ipsla_session = tracked_ipsla_session or []
+        self._uri = None
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+        self.__modified = False
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    def _patch_data(self, data):
+        """
+        Perform a PATCH call to partially update the track object. The tracked
+            sessions are immutable, so only the remaining attributes are sent.
+
+        :param data: dictionary with the attributes to update.
+        """
+        send_data = json.dumps(data, sort_keys=True, indent=4)
+        # session.request does not support PATCH, so use the underlying
+        # requests.Session object with the fully-qualified resource URI.
+        uri = self.session._build_uri(self.path)
+        try:
+            response = self.session.s.patch(
+                uri, verify=False, data=send_data, proxies=self.session.proxy
+            )
+        except Exception as e:
+            raise ResponseError("PATCH", e)
+        if response.status_code not in (200, 204):
+            raise GenericOperationError(response.text, response.status_code)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an IP SLA track object and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all IP SLA track objects and create a
+            dictionary containing each one.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the switch.
+        :return: Dictionary containing track object names as keys and
+            IpslaTrackObject objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        collection = {}
+        for name, uri in data.items():
+            collection[name] = cls.from_uri(session, uri)[1]
+
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an IpslaTrackObject object given a track object URI.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param uri: a String with a URI.
+        :return: Tuple with the track object name and the IpslaTrackObject.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        track = cls(session, name)
+        return name, track
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an IP SLA track object.
+
+        :return: True if the object was modified.
+        """
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PATCH call to apply changes to an existing track object. The
+            name and the tracked sessions are set at creation and are never
+            sent in an update.
+
+        :return: True if object was modified and a PATCH request was made.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        diff = {
+            key: value
+            for key, value in data.items()
+            if self._original_attributes.get(key) != value
+        }
+        for key in ("name", "tracked_ipsla_session"):
+            diff.pop(key, None)
+        if not diff:
+            self.__modified = False
+            return self.__modified
+        self._patch_data(diff)
+        self.__modified = True
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new IP SLA track object using the
+            object's attributes as POST body. Exception is raised if object is
+            unable to be created.
+
+        :return: Boolean, True if entry was created.
+        """
+        data = utils.get_attrs(self, self.config_attrs)
+        # The track object name is the index and must be in the POST body.
+        data["name"] = self.name
+        # The tracked sessions are a list of IP SLA source URIs.
+        if self.tracked_ipsla_session:
+            data["tracked_ipsla_session"] = [
+                "{0}system/ipsla_sources/{1}".format(
+                    self.session.resource_prefix, source.name
+                )
+                for source in self.tracked_ipsla_session
+            ]
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform a DELETE call to erase the IP SLA track object.
+        """
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific IP SLA track object URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        """
+        Getter method for the __modified attribute.
+
+        :return: True if the object was recently modified.
+        """
+        return self.modified

--- a/pyaoscx/rest/v10_16/api.py
+++ b/pyaoscx/rest/v10_16/api.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_16(API):
+    """
+    Represents a REST API Version 10.16. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2024, 12, 6)
+        self.version = "10.16"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            # If user does not pass value for other_config provide default
+            # value, it's needed for correct OSPF Area creation
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_16/interface.py
+++ b/pyaoscx/rest/v10_16/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.16.
+    """
+
+    pass

--- a/tests/test_ipsla.py
+++ b/tests/test_ipsla.py
@@ -1,0 +1,233 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the IpslaSource, IpslaResponder and IpslaTrackObject
+pyaoscx resource modules. The pyaoscx Session is mocked, so no switch is
+required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.ipsla_source import IpslaSource
+from pyaoscx.ipsla_responder import IpslaResponder
+from pyaoscx.ipsla_track_object import IpslaTrackObject
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def fake_vrf(name):
+    obj = MagicMock()
+    obj.name = name
+    return obj
+
+
+def fake_source(name):
+    obj = MagicMock()
+    obj.name = name
+    return obj
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["writable"]
+    api.valid_depth = lambda depth: True
+    session.resource_prefix = "/rest/v10.16/"
+    session.proxy = None
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+
+    patch_calls = []
+
+    def patch(uri, verify=False, data=None, proxies=None):
+        patch_calls.append({"uri": uri, "data": json.loads(data)})
+        return make_response({}, 204)
+
+    session.s.patch.side_effect = patch
+    session._build_uri.side_effect = lambda path: "https://x/" + path
+
+    session.calls = calls
+    session.patch_calls = patch_calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# IpslaSource
+# --------------------------------------------------------------------------
+def test_source_path():
+    session = make_session()
+    source = IpslaSource(session, "src1")
+    assert source.path == "system/ipsla_sources/src1"
+    assert source.name == "src1"
+
+
+def test_source_create_sends_name_vrf_and_attrs():
+    session = make_session()
+    source = IpslaSource(
+        session,
+        "src1",
+        vrf=fake_vrf("default"),
+        type="icmp_echo",
+        frequency=30,
+    )
+    source.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/ipsla_sources"
+    assert post["data"]["name"] == "src1"
+    assert post["data"]["type"] == "icmp_echo"
+    assert post["data"]["frequency"] == 30
+    assert post["data"]["vrf"] == "/rest/v10.16/system/vrfs/default"
+
+
+def test_source_update_idempotent():
+    body = {"frequency": 60, "tos": 0}
+    session = make_session(get_body=body)
+    source = IpslaSource(session, "src1")
+    source.get(selector="writable")
+    assert source.update() is False
+    assert not session.patch_calls
+
+
+def test_source_update_changed_uses_patch():
+    body = {"frequency": 60, "tos": 0}
+    session = make_session(get_body=body)
+    source = IpslaSource(session, "src1")
+    source.get(selector="writable")
+    source.tos = 10
+    assert source.update() is True
+    assert len(session.patch_calls) == 1
+    assert session.patch_calls[0]["data"] == {"tos": 10}
+
+
+def test_source_get_all():
+    body = {"src1": "/rest/v10.16/system/ipsla_sources/src1"}
+    session = make_session(get_body=body)
+    result = IpslaSource.get_all(session)
+    assert "src1" in result
+
+
+# --------------------------------------------------------------------------
+# IpslaResponder
+# --------------------------------------------------------------------------
+def test_responder_path():
+    session = make_session()
+    responder = IpslaResponder(session, "resp1")
+    assert responder.path == "system/ipsla_responders/resp1"
+
+
+def test_responder_create_sends_name_vrf_and_attrs():
+    session = make_session()
+    responder = IpslaResponder(
+        session,
+        "resp1",
+        vrf=fake_vrf("default"),
+        type="udp_echo",
+        responder_port_number=5000,
+    )
+    responder.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/ipsla_responders"
+    assert post["data"]["name"] == "resp1"
+    assert post["data"]["type"] == "udp_echo"
+    assert post["data"]["responder_port_number"] == 5000
+    assert post["data"]["vrf"] == "/rest/v10.16/system/vrfs/default"
+
+
+def test_responder_update_is_noop():
+    session = make_session(get_body={})
+    responder = IpslaResponder(session, "resp1")
+    responder.get()
+    assert responder.update() is False
+    assert not session.patch_calls
+
+
+def test_responder_get_all():
+    body = {"resp1": "/rest/v10.16/system/ipsla_responders/resp1"}
+    session = make_session(get_body=body)
+    result = IpslaResponder.get_all(session)
+    assert "resp1" in result
+
+
+# --------------------------------------------------------------------------
+# IpslaTrackObject
+# --------------------------------------------------------------------------
+def test_track_path():
+    session = make_session()
+    track = IpslaTrackObject(session, "trk1")
+    assert track.path == "system/ipsla_track_objects/trk1"
+
+
+def test_track_create_sends_name_and_tracked_sessions():
+    session = make_session()
+    track = IpslaTrackObject(
+        session,
+        "trk1",
+        tracked_ipsla_session=[fake_source("src1")],
+        track_list_operator="or",
+        up_delay=5,
+    )
+    track.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/ipsla_track_objects"
+    assert post["data"]["name"] == "trk1"
+    assert post["data"]["track_list_operator"] == "or"
+    assert post["data"]["tracked_ipsla_session"] == [
+        "/rest/v10.16/system/ipsla_sources/src1"
+    ]
+
+
+def test_track_update_idempotent():
+    body = {"up_delay": 0, "down_delay": 0, "track_list_operator": "and"}
+    session = make_session(get_body=body)
+    track = IpslaTrackObject(session, "trk1")
+    track.get(selector="writable")
+    assert track.update() is False
+    assert not session.patch_calls
+
+
+def test_track_update_changed_uses_patch():
+    body = {"up_delay": 0, "down_delay": 0, "track_list_operator": "and"}
+    session = make_session(get_body=body)
+    track = IpslaTrackObject(session, "trk1")
+    track.get(selector="writable")
+    track.up_delay = 10
+    assert track.update() is True
+    assert len(session.patch_calls) == 1
+    assert session.patch_calls[0]["data"] == {"up_delay": 10}
+
+
+def test_track_get_all():
+    body = {"trk1": "/rest/v10.16/system/ipsla_track_objects/trk1"}
+    session = make_session(get_body=body)
+    result = IpslaTrackObject.get_all(session)
+    assert "trk1" in result


### PR DESCRIPTION
## Description

Add three new resource modules for IP SLA configuration: `IpslaSource`,
`IpslaResponder` and `IpslaTrackObject`. Fixes #68.

### IpslaSource (`system/ipsla_sources`)

Full lifecycle. A full PUT fails on this resource (the writable readback
returns an out-of-range `history_interval` default and a partial PUT reports
the mandatory `vrf` as missing), so updates are applied with a PATCH request
that sends only the changed attributes. The `name`, `type` and `vrf` are set
at creation time. The `vrf` is passed as a `Vrf` object and serialized to a
URI on creation.

### IpslaResponder (`system/ipsla_responders`)

Create and delete only. The responder has no writable attributes (the
writable selector returns an empty object), so all attributes are set at
creation time and the resource is recreated to apply a change.

### IpslaTrackObject (`system/ipsla_track_objects`)

The scalar attributes (`down_delay`, `track_list_operator`, `up_delay`) are
updated with a PATCH request. The tracked IP SLA sessions
(`tracked_ipsla_session`) are passed as a list of `IpslaSource` objects, set
at creation time, and are not modifiable.

### REST version

`ipsla_track_objects` requires REST API version **10.16**, so a new `v10_16`
REST version is added and the whole family is standardized on it. The new
modules are registered in the API dispatcher.

## Testing

- Added offline unit tests (`tests/test_ipsla.py`, 14 tests) covering create,
  PATCH update, idempotency and `get_all` for the three resources.
- Verified the full lifecycle live against a 6300 (FL.10.17) switch at REST
  v10.16: create, readback, PATCH update, idempotent re-apply and delete for
  all three resources, including a track object referencing a source.

## Note

`PATCH` is performed through the underlying `requests.Session` because
`Session.request()` only dispatches `PUT`/`GET`/`POST`/`DELETE`.

Companion collection PR: aruba/aoscx-ansible-collection#152
