### PR TITLE
Add AAA server family resources (server groups, RADIUS and TACACS+ servers)

### DIFF
--- a/pyaoscx/aaa_server_group.py
+++ b/pyaoscx/aaa_server_group.py
@@ -1,0 +1,270 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class AaaServerGroup(PyaoscxModule):
+    """
+    Provide configuration management for AAA Server Groups on AOS-CX devices.
+    """
+
+    base_uri = "system/aaa_server_groups"
+    resource_uri_name = "aaa_server_groups"
+
+    indices = ["group_name"]
+
+    def __init__(self, session, group_name, uri=None, **kwargs):
+        self.session = session
+        self.group_name = group_name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.group_name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an AAA Server Group and fill
+            the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "group_name" in data:
+            data.pop("group_name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["group_name"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all AAA Server Groups, and create a
+            dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the group names as keys and the
+            AaaServerGroup objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        groups = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            indices, group = cls.from_uri(session, uri)
+            groups[indices] = group
+
+        return groups
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing AAA Server
+            Group.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing AAA Server Group.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        group_data = utils.get_attrs(self, self.config_attrs)
+
+        if group_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(group_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = group_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new AAA Server Group. Only returns if
+            no exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        group_data = utils.get_attrs(self, self.config_attrs)
+        group_data["group_name"] = self.group_name
+
+        post_data = json.dumps(group_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete an AAA Server Group.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create an AaaServerGroup object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {group_name: "/rest/v10.xx/system/aaa_server_groups/group_name"}
+        :return: AaaServerGroup object.
+        """
+        group_arr = session.api.get_keys(response_data, cls.resource_uri_name)
+        group_name = group_arr[0]
+        return cls(session, group_name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an AaaServerGroup object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the AaaServerGroup object.
+        """
+        index_pattern = re.compile(r"(.*)aaa_server_groups/(?P<index>.+)")
+        group_name = index_pattern.match(uri).group("index")
+
+        group = cls(session, group_name)
+        return group_name, group
+
+    def __str__(self):
+        return "AaaServerGroup group_name:{0}".format(self.group_name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific AAA Server Group URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.group_name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,9 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "AaaServerGroup": "aaa_server_group",
+            "RadiusServer": "radius_server",
+            "TacacsServer": "tacacs_server",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/radius_server.py
+++ b/pyaoscx/radius_server.py
@@ -1,0 +1,288 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusServer(PyaoscxModule):
+    """
+    Provide configuration management for RADIUS servers on AOS-CX devices.
+        RADIUS servers are nested under a VRF and indexed by the compound key
+        address, port and port_type.
+    """
+
+    collection_uri = "system/vrfs/{name}/radius_servers"
+    resource_uri_name = "radius_servers"
+
+    indices = ["address", "port", "port_type"]
+
+    def __init__(
+        self,
+        session,
+        vrf,
+        address,
+        port=1812,
+        port_type="udp",
+        uri=None,
+        **kwargs
+    ):
+        self.session = session
+        # vrf is a Vrf object used as the parent in the URI path
+        self.vrf = vrf
+        self.address = address
+        self.port = port
+        self.port_type = port_type
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri.format(name=self.vrf.name)
+        self.path = "{0}/{1}".format(self.base_uri, self._index_id())
+
+    def _index_id(self):
+        sep = self.session.api.compound_index_separator
+        return sep.join(
+            [str(self.address), str(self.port), str(self.port_type)]
+        )
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a RADIUS server and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        for index in self.indices + ["vrf"]:
+            if index in data:
+                data.pop(index)
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(
+                self, data, "config_attrs", self.indices + ["vrf"]
+            )
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, vrf):
+        """
+        Perform a GET call to retrieve all RADIUS servers under a VRF, and
+            create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object.
+        :param vrf: Vrf object the RADIUS servers belong to.
+        :return: Dictionary containing the compound indices as keys and the
+            RadiusServer objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=vrf.name)
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        servers = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for server_uri in uri_list:
+            indices, server = cls.from_uri(session, vrf, server_uri)
+            servers[indices] = server
+
+        return servers
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing RADIUS server.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing RADIUS server.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        server_data = utils.get_attrs(self, self.config_attrs)
+
+        if server_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(server_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = server_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new RADIUS server. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        server_data = utils.get_attrs(self, self.config_attrs)
+        server_data["address"] = self.address
+        server_data["port"] = self.port
+        server_data["port_type"] = self.port_type
+        server_data["vrf"] = self.vrf.get_uri()
+
+        post_data = json.dumps(server_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a RADIUS server.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, vrf, uri):
+        """
+        Create a RadiusServer object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param vrf: Vrf object the RADIUS server belongs to.
+        :param uri: a String with a URI.
+        :return: tuple containing both the compound index and the RadiusServer
+            object.
+        """
+        index_pattern = re.compile(r"(.*)radius_servers/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        address, port, port_type = index.split(
+            session.api.compound_index_separator
+        )
+
+        server = cls(session, vrf, address, int(port), port_type)
+        return index, server
+
+    def __str__(self):
+        return "RadiusServer address:{0}, port:{1}, port_type:{2}".format(
+            self.address, self.port, self.port_type
+        )
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific RADIUS server URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/rest/v10_16/api.py
+++ b/pyaoscx/rest/v10_16/api.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_16(API):
+    """
+    Represents a REST API Version 10.16. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2024, 12, 6)
+        self.version = "10.16"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            # If user does not pass value for other_config provide default
+            # value, it's needed for correct OSPF Area creation
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_16/interface.py
+++ b/pyaoscx/rest/v10_16/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.16.
+    """
+
+    pass

--- a/pyaoscx/tacacs_server.py
+++ b/pyaoscx/tacacs_server.py
@@ -1,0 +1,273 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class TacacsServer(PyaoscxModule):
+    """
+    Provide configuration management for TACACS+ servers on AOS-CX devices.
+        TACACS+ servers are nested under a VRF and indexed by the compound key
+        address and tcp_port.
+    """
+
+    collection_uri = "system/vrfs/{name}/tacacs_servers"
+    resource_uri_name = "tacacs_servers"
+
+    indices = ["address", "tcp_port"]
+
+    def __init__(self, session, vrf, address, tcp_port=49, uri=None, **kwargs):
+        self.session = session
+        # vrf is a Vrf object used as the parent in the URI path
+        self.vrf = vrf
+        self.address = address
+        self.tcp_port = tcp_port
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri.format(name=self.vrf.name)
+        self.path = "{0}/{1}".format(self.base_uri, self._index_id())
+
+    def _index_id(self):
+        sep = self.session.api.compound_index_separator
+        return sep.join([str(self.address), str(self.tcp_port)])
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a TACACS+ server and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        for index in self.indices + ["vrf"]:
+            if index in data:
+                data.pop(index)
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(
+                self, data, "config_attrs", self.indices + ["vrf"]
+            )
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, vrf):
+        """
+        Perform a GET call to retrieve all TACACS+ servers under a VRF, and
+            create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object.
+        :param vrf: Vrf object the TACACS+ servers belong to.
+        :return: Dictionary containing the compound indices as keys and the
+            TacacsServer objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=vrf.name)
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        servers = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for server_uri in uri_list:
+            indices, server = cls.from_uri(session, vrf, server_uri)
+            servers[indices] = server
+
+        return servers
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing TACACS+ server.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing TACACS+ server.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        server_data = utils.get_attrs(self, self.config_attrs)
+
+        if server_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(server_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = server_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new TACACS+ server. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        server_data = utils.get_attrs(self, self.config_attrs)
+        server_data["address"] = self.address
+        server_data["tcp_port"] = self.tcp_port
+        server_data["vrf"] = self.vrf.get_uri()
+
+        post_data = json.dumps(server_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a TACACS+ server.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, vrf, uri):
+        """
+        Create a TacacsServer object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param vrf: Vrf object the TACACS+ server belongs to.
+        :param uri: a String with a URI.
+        :return: tuple containing both the compound index and the TacacsServer
+            object.
+        """
+        index_pattern = re.compile(r"(.*)tacacs_servers/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        address, tcp_port = index.split(session.api.compound_index_separator)
+
+        server = cls(session, vrf, address, int(tcp_port))
+        return index, server
+
+    def __str__(self):
+        return "TacacsServer address:{0}, tcp_port:{1}".format(
+            self.address, self.tcp_port
+        )
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific TACACS+ server URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/tests/test_aaa.py
+++ b/tests/test_aaa.py
@@ -1,0 +1,262 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the AaaServerGroup, RadiusServer and TacacsServer
+pyaoscx resource modules. The pyaoscx Session is mocked, so no switch is
+required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.aaa_server_group import AaaServerGroup
+from pyaoscx.radius_server import RadiusServer
+from pyaoscx.tacacs_server import TacacsServer
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def fake_vrf(name):
+    obj = MagicMock()
+    obj.name = name
+    obj.get_uri.return_value = "/rest/v10.16/system/vrfs/{0}".format(name)
+    return obj
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["writable"]
+    api.valid_depth = lambda depth: True
+    api.compound_index_separator = ","
+    api.get_uri_from_data.side_effect = lambda data: list(data.values())
+    session.resource_prefix = "/rest/v10.16/"
+    session.proxy = None
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# AaaServerGroup
+# --------------------------------------------------------------------------
+def test_group_path():
+    session = make_session()
+    group = AaaServerGroup(session, "grp1")
+    assert group.path == "system/aaa_server_groups/grp1"
+    assert group.group_name == "grp1"
+
+
+def test_group_create_sends_name_and_attrs():
+    session = make_session()
+    group = AaaServerGroup(session, "grp1", group_type="radius")
+    group.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/aaa_server_groups"
+    assert post["data"]["group_name"] == "grp1"
+    assert post["data"]["group_type"] == "radius"
+
+
+def test_group_update_idempotent():
+    session = make_session(get_body={"group_type": "tacacs"})
+    group = AaaServerGroup(session, "grp1")
+    group.get(selector="writable")
+    assert group.update() is False
+    assert not [c for c in session.calls if c["method"] == "PUT"]
+
+
+def test_group_update_changed_uses_put():
+    session = make_session(get_body={"group_type": "tacacs"})
+    group = AaaServerGroup(session, "grp1")
+    group.get(selector="writable")
+    group.group_type = "radius"
+    assert group.update() is True
+    puts = [c for c in session.calls if c["method"] == "PUT"]
+    assert len(puts) == 1
+    assert puts[0]["data"] == {"group_type": "radius"}
+
+
+def test_group_delete():
+    session = make_session()
+    group = AaaServerGroup(session, "grp1")
+    group.delete()
+    assert [c for c in session.calls if c["method"] == "DELETE"]
+
+
+def test_group_get_all():
+    body = {"grp1": "/rest/v10.16/system/aaa_server_groups/grp1"}
+    session = make_session(get_body=body)
+    result = AaaServerGroup.get_all(session)
+    assert "grp1" in result
+
+
+# --------------------------------------------------------------------------
+# RadiusServer
+# --------------------------------------------------------------------------
+def test_radius_path_compound_index():
+    session = make_session()
+    server = RadiusServer(
+        session, fake_vrf("default"), "192.0.2.50", 1812, "udp"
+    )
+    assert server.base_uri == "system/vrfs/default/radius_servers"
+    assert server.path == (
+        "system/vrfs/default/radius_servers/192.0.2.50,1812,udp"
+    )
+
+
+def test_radius_create_sends_index_vrf_and_attrs():
+    session = make_session()
+    server = RadiusServer(
+        session,
+        fake_vrf("default"),
+        "192.0.2.50",
+        1812,
+        "udp",
+        timeout=10,
+        server_group={"/rest/v10.16/system/aaa_server_groups/g": 1},
+    )
+    server.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/vrfs/default/radius_servers"
+    assert post["data"]["address"] == "192.0.2.50"
+    assert post["data"]["port"] == 1812
+    assert post["data"]["port_type"] == "udp"
+    assert post["data"]["vrf"] == "/rest/v10.16/system/vrfs/default"
+    assert post["data"]["timeout"] == 10
+    assert post["data"]["server_group"] == {
+        "/rest/v10.16/system/aaa_server_groups/g": 1
+    }
+
+
+def test_radius_update_idempotent():
+    session = make_session(get_body={"timeout": 5})
+    server = RadiusServer(
+        session, fake_vrf("default"), "192.0.2.50", 1812, "udp"
+    )
+    server.get(selector="writable")
+    assert server.update() is False
+    assert not [c for c in session.calls if c["method"] == "PUT"]
+
+
+def test_radius_update_changed_uses_put():
+    session = make_session(get_body={"timeout": 5})
+    server = RadiusServer(
+        session, fake_vrf("default"), "192.0.2.50", 1812, "udp"
+    )
+    server.get(selector="writable")
+    server.timeout = 20
+    assert server.update() is True
+    puts = [c for c in session.calls if c["method"] == "PUT"]
+    assert len(puts) == 1
+    assert puts[0]["data"] == {"timeout": 20}
+
+
+def test_radius_get_pops_indices():
+    body = {"timeout": 5, "address": "192.0.2.50", "vrf": "x"}
+    session = make_session(get_body=body)
+    server = RadiusServer(
+        session, fake_vrf("default"), "192.0.2.50", 1812, "udp"
+    )
+    server.get(selector="writable")
+    assert "address" not in server.config_attrs
+    assert "vrf" not in server.config_attrs
+    assert "timeout" in server.config_attrs
+
+
+def test_radius_get_all():
+    body = {
+        "192.0.2.50,1812,udp": (
+            "/rest/v10.16/system/vrfs/default/radius_servers/"
+            "192.0.2.50,1812,udp"
+        )
+    }
+    session = make_session(get_body=body)
+    result = RadiusServer.get_all(session, fake_vrf("default"))
+    assert "192.0.2.50,1812,udp" in result
+
+
+# --------------------------------------------------------------------------
+# TacacsServer
+# --------------------------------------------------------------------------
+def test_tacacs_path_compound_index():
+    session = make_session()
+    server = TacacsServer(session, fake_vrf("default"), "192.0.2.60", 49)
+    assert server.base_uri == "system/vrfs/default/tacacs_servers"
+    assert server.path == ("system/vrfs/default/tacacs_servers/192.0.2.60,49")
+
+
+def test_tacacs_create_sends_index_vrf_and_attrs():
+    session = make_session()
+    server = TacacsServer(
+        session,
+        fake_vrf("default"),
+        "192.0.2.60",
+        49,
+        default_group_priority=1,
+        group=["/rest/v10.16/system/aaa_server_groups/g"],
+        timeout=10,
+    )
+    server.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/vrfs/default/tacacs_servers"
+    assert post["data"]["address"] == "192.0.2.60"
+    assert post["data"]["tcp_port"] == 49
+    assert post["data"]["vrf"] == "/rest/v10.16/system/vrfs/default"
+    assert post["data"]["group"] == ["/rest/v10.16/system/aaa_server_groups/g"]
+    assert post["data"]["default_group_priority"] == 1
+
+
+def test_tacacs_update_idempotent():
+    session = make_session(get_body={"timeout": 5})
+    server = TacacsServer(session, fake_vrf("default"), "192.0.2.60", 49)
+    server.get(selector="writable")
+    assert server.update() is False
+    assert not [c for c in session.calls if c["method"] == "PUT"]
+
+
+def test_tacacs_delete():
+    session = make_session()
+    server = TacacsServer(session, fake_vrf("default"), "192.0.2.60", 49)
+    server.delete()
+    assert [c for c in session.calls if c["method"] == "DELETE"]
+
+
+def test_tacacs_get_all():
+    body = {
+        "192.0.2.60,49": (
+            "/rest/v10.16/system/vrfs/default/tacacs_servers/192.0.2.60,49"
+        )
+    }
+    session = make_session(get_body=body)
+    result = TacacsServer.get_all(session, fake_vrf("default"))
+    assert "192.0.2.60,49" in result


### PR DESCRIPTION
## Description

Adds three new resource modules to manage the AAA server family on AOS-CX
devices, plus the v10.16 REST version module they rely on.

- `pyaoscx/aaa_server_group.py` — `AaaServerGroup` (`system/aaa_server_groups`,
  index `group_name`, attribute `group_type`).
- `pyaoscx/radius_server.py` — `RadiusServer`
  (`system/vrfs/{vrf}/radius_servers`, VRF-nested, compound index
  `address,port,port_type`). Supports the `server_group` binding
  (`{group_uri: priority}`, several groups allowed), the write-only `passkey`
  and the usual RADIUS scalars (auth_type, accounting_udp_port, retries,
  timeout, tls_initial_connection_timeout, msg_authenticator_check,
  tracking_*, port_access).
- `pyaoscx/tacacs_server.py` — `TacacsServer`
  (`system/vrfs/{vrf}/tacacs_servers`, VRF-nested, compound index
  `address,tcp_port`). Supports `group` membership, the write-only `passkey`
  and the TACACS+ scalars (auth_type, timeout, tracking_enable,
  default_group_priority, user_group_priority).

All three classes are registered in `pyaoscx/api.py` and use a PUT-based
`update()`. This change also adds the `pyaoscx/rest/v10_16/` API version module
(required for the RADIUS `server_group` dict binding) and 17 offline unit tests
in `tests/test_aaa.py`.

Fixes #70

## Testing

- `black --line-length 79 --check` and `flake8` clean on all new files.
- `pytest tests/test_aaa.py` — 17/17 passing.
- Validated live against an AOS-CX 6300 (FL.10.17, REST v10.16): create /
  read-back / idempotent update / delete for all three resources, including a
  multi-group `server_group` binding that reproduces a production
  ClearPass-style RADIUS profile. No production resources were modified.

## Note on contribution target

`CONTRIBUTING.md` mentions a `development` branch, but the repository only
exposes `master`, so this PR targets `master`. Happy to retarget if a
`development` branch is created.

Companion collection PR: aruba/aoscx-ansible-collection#158
