### PR TITLE
Add port access (NAC) resource classes

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,9 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "CaptivePortalProfile": "captive_portal_profile",
+            "PortAccessRole": "port_access_role",
+            "PortAccessVlanGroup": "port_access_vlan_group",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -170,6 +170,9 @@ class API(ABC):
             "PortAccessVlanGroup": "port_access_vlan_group",
             "Class": "class",
             "ClassEntry": "class_entry",
+            "PortAccessGbp": "port_access_gbp",
+            "PortAccessAbp": "port_access_abp",
+            "PortAccessPolicy": "port_access_policy",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -168,6 +168,8 @@ class API(ABC):
             "CaptivePortalProfile": "captive_portal_profile",
             "PortAccessRole": "port_access_role",
             "PortAccessVlanGroup": "port_access_vlan_group",
+            "Class": "class",
+            "ClassEntry": "class_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/captive_portal_profile.py
+++ b/pyaoscx/captive_portal_profile.py
@@ -1,0 +1,277 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class CaptivePortalProfile(PyaoscxModule):
+    """
+    Provide configuration management for Captive Portal Profiles on AOS-CX
+        devices.
+    """
+
+    base_uri = "system/captive_portal_profiles"
+    resource_uri_name = "captive_portal_profiles"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Captive Portal Profile and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "name" in data:
+            data.pop("name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Captive Portal Profiles, and create
+            a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the names as keys and the
+            CaptivePortalProfile objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        profiles = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            indices, profile = cls.from_uri(session, uri)
+            profiles[indices] = profile
+
+        return profiles
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Captive Portal
+            Profile.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Captive Portal
+            Profile.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        profile_data = utils.get_attrs(self, self.config_attrs)
+
+        if profile_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(profile_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = profile_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Captive Portal Profile. Only
+            returns if no exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        profile_data = utils.get_attrs(self, self.config_attrs)
+        profile_data["name"] = self.name
+
+        post_data = json.dumps(profile_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a Captive Portal Profile.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a CaptivePortalProfile object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {name: "/rest/v10.xx/system/captive_portal_profiles/name"}
+        :return: CaptivePortalProfile object.
+        """
+        profile_arr = session.api.get_keys(
+            response_data, cls.resource_uri_name
+        )
+        name = profile_arr[0]
+        return cls(session, name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a CaptivePortalProfile object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the
+            CaptivePortalProfile object.
+        """
+        index_pattern = re.compile(
+            r"(.*)captive_portal_profiles/(?P<index>.+)"
+        )
+        name = index_pattern.match(uri).group("index")
+
+        profile = cls(session, name)
+        return name, profile
+
+    def __str__(self):
+        return "CaptivePortalProfile name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific Captive Portal Profile URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/class.py
+++ b/pyaoscx/class.py
@@ -1,0 +1,282 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class Class(PyaoscxModule):
+    """
+    Provide configuration management for traffic Classes on AOS-CX devices.
+    A traffic Class is identified by the compound index of its name and type.
+    """
+
+    base_uri = "system/classes"
+    resource_uri_name = "classes"
+
+    indices = ["name", "type"]
+
+    def __init__(self, session, name, type=None, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self.type = type
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.__index = "{0}{1}{2}".format(
+            name, session.api.compound_index_separator, type
+        )
+        self.path = "{0}/{1}".format(self.base_uri, self.__index)
+
+    @property
+    def index(self):
+        return self.__index
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a traffic Class and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        for index in self.indices:
+            if index in data:
+                data.pop(index)
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", self.indices)
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all traffic Classes, and create a
+            dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the compound indices as keys and the
+            Class objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        classes = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            index, traffic_class = cls.from_uri(session, uri)
+            classes[index] = traffic_class
+
+        return classes
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing traffic Class.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing traffic Class.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        class_data = utils.get_attrs(self, self.config_attrs)
+
+        if class_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(class_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = class_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new traffic Class. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if the Class was created.
+        """
+        class_data = utils.get_attrs(self, self.config_attrs)
+        class_data["name"] = self.name
+        class_data["type"] = self.type
+
+        post_data = json.dumps(class_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a traffic Class.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a Class object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {index: "/rest/v10.xx/system/classes/name,type"}
+        :return: Class object.
+        """
+        class_arr = session.api.get_keys(response_data, cls.resource_uri_name)
+        index = class_arr[0]
+        name, type_ = index.split(session.api.compound_index_separator)
+        return cls(session, name, type=type_)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a Class object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the compound index and the Class object.
+        """
+        index_pattern = re.compile(r"(.*)classes/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        name, type_ = index.split(session.api.compound_index_separator)
+
+        traffic_class = cls(session, name, type=type_)
+        return index, traffic_class
+
+    def __str__(self):
+        return "Class name:{0} type:{1}".format(self.name, self.type)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific traffic Class URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.__index,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/class_entry.py
+++ b/pyaoscx/class_entry.py
@@ -1,0 +1,269 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class ClassEntry(PyaoscxModule):
+    """
+    Provide configuration management for traffic Class entries on AOS-CX
+        devices.
+    """
+
+    collection_uri = "system/classes/{index}/cfg_entries"
+    object_uri = collection_uri + "/{sequence_number}"
+    resource_name = "sequence_number"
+    indices = ["sequence_number"]
+
+    def __init__(
+        self, session, sequence_number, parent_class, uri=None, **kwargs
+    ):
+        self.__parent_class = parent_class
+        self.__sequence_number = sequence_number
+        self.session = session
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = self.object_uri.format(
+            index=parent_class.index, sequence_number=sequence_number
+        )
+        self.base_uri = self.collection_uri.format(index=parent_class.index)
+
+    @property
+    def sequence_number(self):
+        return self.__sequence_number
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a traffic Class entry and fill
+            the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "sequence_number" in data:
+            data.pop("sequence_number")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(
+                self, data, "config_attrs", ["sequence_number"]
+            )
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, parent_class):
+        """
+        Perform a GET call to retrieve all entries of a traffic Class and
+            create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param parent_class: Class object to which the entries belong.
+        :return: Dictionary containing the sequence numbers as keys and the
+            ClassEntry objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(index=parent_class.index)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        entries = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            sequence_number, entry = cls.from_uri(session, parent_class, uri)
+            entries[sequence_number] = entry
+
+        return entries
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing traffic Class
+            entry.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing traffic Class entry.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        entry_data = utils.get_attrs(self, self.config_attrs)
+
+        if entry_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(entry_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = entry_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new traffic Class entry. Only returns
+            if no exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        entry_data = utils.get_attrs(self, self.config_attrs)
+        entry_data["sequence_number"] = self.sequence_number
+
+        post_data = json.dumps(entry_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a traffic Class entry.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, parent_class, uri):
+        """
+        Create a ClassEntry object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param parent_class: Class object to which the entry belongs.
+        :param uri: a String with a URI.
+        :return: tuple containing both the sequence number and the ClassEntry
+            object.
+        """
+        sequence_number = uri.split("/")[-1]
+        entry = cls(session, sequence_number, parent_class)
+        return sequence_number, entry
+
+    def __str__(self):
+        return "ClassEntry sequence_number:{0}".format(self.sequence_number)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific traffic Class entry URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix,
+                self.path,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/port_access_abp.py
+++ b/pyaoscx/port_access_abp.py
@@ -1,0 +1,36 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.port_access_policy_common import (
+    PortAccessActionSet,
+    PortAccessPolicyContainer,
+    PortAccessPolicyEntry,
+)
+
+
+class PortAccessAbpActionSet(PortAccessActionSet):
+    """
+    Action set of an Application Based Policy entry (drop, dscp,
+        local_priority, mirror).
+    """
+
+    action_key = "abp_action_set"
+
+
+class PortAccessAbpEntry(PortAccessPolicyEntry):
+    """
+    Entry of an Application Based Policy.
+    """
+
+    action_set_class = PortAccessAbpActionSet
+
+
+class PortAccessAbp(PortAccessPolicyContainer):
+    """
+    Provide configuration management for Application Based Policies on AOS-CX
+        devices.
+    """
+
+    base_uri = "system/port_access_abps"
+    resource_uri_name = "port_access_abps"
+    entry_class = PortAccessAbpEntry

--- a/pyaoscx/port_access_gbp.py
+++ b/pyaoscx/port_access_gbp.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.port_access_policy_common import (
+    PortAccessActionSet,
+    PortAccessPolicyContainer,
+    PortAccessPolicyEntry,
+)
+
+
+class PortAccessGbpActionSet(PortAccessActionSet):
+    """
+    Action set of a Group Based Policy entry (drop, reflect).
+    """
+
+    action_key = "gbp_action_set"
+
+
+class PortAccessGbpEntry(PortAccessPolicyEntry):
+    """
+    Entry of a Group Based Policy.
+    """
+
+    action_set_class = PortAccessGbpActionSet
+
+
+class PortAccessGbp(PortAccessPolicyContainer):
+    """
+    Provide configuration management for Group Based Policies on AOS-CX
+        devices.
+    """
+
+    base_uri = "system/port_access_gbps"
+    resource_uri_name = "port_access_gbps"
+    entry_class = PortAccessGbpEntry

--- a/pyaoscx/port_access_policy.py
+++ b/pyaoscx/port_access_policy.py
@@ -1,0 +1,36 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.port_access_policy_common import (
+    PortAccessActionSet,
+    PortAccessPolicyContainer,
+    PortAccessPolicyEntry,
+)
+
+
+class PortAccessPolicyActionSet(PortAccessActionSet):
+    """
+    Action set of a Port Access Policy entry (drop, reflect, dscp, cir, cbs,
+        pcp, ecn, ip_precedence, local_priority, exceed_drop, redirect).
+    """
+
+    action_key = "policy_action_set"
+
+
+class PortAccessPolicyEntryItem(PortAccessPolicyEntry):
+    """
+    Entry of a Port Access Policy.
+    """
+
+    action_set_class = PortAccessPolicyActionSet
+
+
+class PortAccessPolicy(PortAccessPolicyContainer):
+    """
+    Provide configuration management for Port Access Policies on AOS-CX
+        devices.
+    """
+
+    base_uri = "system/port_access_policies"
+    resource_uri_name = "port_access_policies"
+    entry_class = PortAccessPolicyEntryItem

--- a/pyaoscx/port_access_policy_common.py
+++ b/pyaoscx/port_access_policy_common.py
@@ -1,0 +1,761 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Common base classes for the Port Access policy families (Group Based Policy,
+Application Based Policy and Port Access Policy).
+
+The three families share the exact same three level shape::
+
+    container (system/port_access_<family>s, indexed by name)
+      -> cfg_entries/{sequence_number} (traffic class reference + comment)
+           -> <family>_action_set (drop, ... family specific fields)
+
+Each family provides thin subclasses that only set ``base_uri`` /
+``resource_uri_name`` (container) and ``action_key`` (action set).
+"""
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class PortAccessPolicyContainer(PyaoscxModule):
+    """
+    Base class for a Port Access policy family container, indexed by name.
+    Subclasses must set ``base_uri`` and ``resource_uri_name``.
+    """
+
+    base_uri = None
+    resource_uri_name = None
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self._modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a policy container and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "name" in data:
+            data.pop("name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all containers of this family and create
+            a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the names as keys and the objects as
+            values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        containers = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            index, container = cls.from_uri(session, uri)
+            containers[index] = container
+
+        return containers
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing policy
+            container.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self._modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing policy container.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        container_data = utils.get_attrs(self, self.config_attrs)
+
+        if container_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(container_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = container_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new policy container. Only returns if
+            no exception is raised.
+
+        :return: Boolean, True if container was created.
+        """
+        container_data = utils.get_attrs(self, self.config_attrs)
+        container_data["name"] = self.name
+
+        post_data = json.dumps(container_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a policy container.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a policy container object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {name: "/rest/v10.xx/system/port_access_<family>s/name"}
+        :return: policy container object.
+        """
+        container_arr = session.api.get_keys(
+            response_data, cls.resource_uri_name
+        )
+        name = container_arr[0]
+        return cls(session, name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a policy container object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the object.
+        """
+        index_pattern = re.compile(
+            r"(.*){0}/(?P<index>.+)".format(cls.resource_uri_name)
+        )
+        name = index_pattern.match(uri).group("index")
+
+        container = cls(session, name)
+        return name, container
+
+    def __str__(self):
+        return "{0} name:{1}".format(type(self).__name__, self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific policy container URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self._modified
+
+
+class PortAccessPolicyEntry(PyaoscxModule):
+    """
+    Base class for a Port Access policy entry, child of a container and indexed
+    by sequence_number. Holds the referenced traffic class and a comment.
+    """
+
+    resource_name = "sequence_number"
+    indices = ["sequence_number"]
+
+    def __init__(
+        self, session, sequence_number, parent_container, uri=None, **kwargs
+    ):
+        self.__parent_container = parent_container
+        self.__sequence_number = sequence_number
+        self.session = session
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self._modified = False
+        self.base_uri = "{0}/cfg_entries".format(parent_container.path)
+        self.path = "{0}/{1}".format(self.base_uri, sequence_number)
+
+    @property
+    def sequence_number(self):
+        return self.__sequence_number
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a policy entry and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "sequence_number" in data:
+            data.pop("sequence_number")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(
+                self, data, "config_attrs", ["sequence_number"]
+            )
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, parent_container):
+        """
+        Perform a GET call to retrieve all entries of a container and create a
+            dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object.
+        :param parent_container: container object to which the entries belong.
+        :return: Dictionary keyed by sequence number with the entry objects as
+            values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = "{0}/cfg_entries".format(parent_container.path)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        entries = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            sequence_number, entry = cls.from_uri(
+                session, parent_container, uri
+            )
+            entries[sequence_number] = entry
+
+        return entries
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing policy entry.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self._modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing policy entry.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        entry_data = utils.get_attrs(self, self.config_attrs)
+
+        if entry_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(entry_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = entry_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new policy entry. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        entry_data = utils.get_attrs(self, self.config_attrs)
+        entry_data["sequence_number"] = self.sequence_number
+
+        post_data = json.dumps(entry_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a policy entry.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, parent_container, uri):
+        """
+        Create a policy entry object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param parent_container: container object to which the entry belongs.
+        :param uri: a String with a URI.
+        :return: tuple containing both the sequence number and the object.
+        """
+        sequence_number = uri.split("/")[-1]
+        entry = cls(session, sequence_number, parent_container)
+        return sequence_number, entry
+
+    def __str__(self):
+        return "{0} sequence_number:{1}".format(
+            type(self).__name__, self.sequence_number
+        )
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific policy entry URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix,
+                self.path,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self._modified
+
+
+class PortAccessActionSet(PyaoscxModule):
+    """
+    Base class for a Port Access policy entry action set. It is a singleton
+    child of an entry reachable at ``<entry>/<action_key>``. Subclasses must
+    set ``action_key``.
+    """
+
+    action_key = None
+
+    def __init__(self, session, parent_entry, uri=None, **kwargs):
+        self.__parent_entry = parent_entry
+        self.session = session
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self._modified = False
+        self.path = "{0}/{1}".format(parent_entry.path, self.action_key)
+        self.base_uri = self.path
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an action set and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", [])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, parent_entry):
+        """
+        Retrieve the singleton action set of an entry, if it exists.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object.
+        :param parent_entry: entry object to which the action set belongs.
+        :return: Dictionary keyed by the action key with the action set object
+            as value, or an empty dictionary when it does not exist.
+        """
+        action = cls(session, parent_entry)
+        try:
+            action.get()
+        except GenericOperationError:
+            return {}
+        return {cls.action_key: action}
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing action set.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self._modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing action set.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        action_data = utils.get_attrs(self, self.config_attrs)
+
+        if action_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(action_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = action_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new action set. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if action set was created.
+        """
+        action_data = utils.get_attrs(self, self.config_attrs)
+
+        post_data = json.dumps(action_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete an action set.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    def __str__(self):
+        return "{0}".format(type(self).__name__)
+
+    @classmethod
+    def from_uri(cls, session, parent_entry, uri):
+        """
+        Create an action set object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param parent_entry: entry object to which the action set belongs.
+        :param uri: a String with a URI.
+        :return: tuple containing the action key and the action set object.
+        """
+        action = cls(session, parent_entry)
+        return cls.action_key, action
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific action set URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix,
+                self.path,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self._modified

--- a/pyaoscx/port_access_role.py
+++ b/pyaoscx/port_access_role.py
@@ -1,0 +1,270 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class PortAccessRole(PyaoscxModule):
+    """
+    Provide configuration management for Port Access Roles on AOS-CX devices.
+    """
+
+    base_uri = "system/port_access_roles"
+    resource_uri_name = "port_access_roles"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Port Access Role and fill
+            the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "name" in data:
+            data.pop("name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Port Access Roles, and create a
+            dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the names as keys and the
+            PortAccessRole objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        roles = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            indices, role = cls.from_uri(session, uri)
+            roles[indices] = role
+
+        return roles
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Port Access
+            Role.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Port Access Role.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        role_data = utils.get_attrs(self, self.config_attrs)
+
+        if role_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(role_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = role_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Port Access Role. Only returns if
+            no exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        role_data = utils.get_attrs(self, self.config_attrs)
+        role_data["name"] = self.name
+
+        post_data = json.dumps(role_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a Port Access Role.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a PortAccessRole object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {name: "/rest/v10.xx/system/port_access_roles/name"}
+        :return: PortAccessRole object.
+        """
+        role_arr = session.api.get_keys(response_data, cls.resource_uri_name)
+        name = role_arr[0]
+        return cls(session, name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a PortAccessRole object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the PortAccessRole object.
+        """
+        index_pattern = re.compile(r"(.*)port_access_roles/(?P<index>.+)")
+        name = index_pattern.match(uri).group("index")
+
+        role = cls(session, name)
+        return name, role
+
+    def __str__(self):
+        return "PortAccessRole name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific Port Access Role URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/port_access_vlan_group.py
+++ b/pyaoscx/port_access_vlan_group.py
@@ -1,0 +1,275 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class PortAccessVlanGroup(PyaoscxModule):
+    """
+    Provide configuration management for Port Access VLAN Groups on AOS-CX
+        devices.
+    """
+
+    base_uri = "system/port_access_vlan_groups"
+    resource_uri_name = "port_access_vlan_groups"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Port Access VLAN Group and
+            fill the object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "name" in data:
+            data.pop("name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Port Access VLAN Groups, and create
+            a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the names as keys and the
+            PortAccessVlanGroup objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        groups = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            indices, group = cls.from_uri(session, uri)
+            groups[indices] = group
+
+        return groups
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Port Access
+            VLAN Group.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Port Access VLAN
+            Group.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        group_data = utils.get_attrs(self, self.config_attrs)
+
+        if group_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(group_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = group_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Port Access VLAN Group. Only
+            returns if no exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        group_data = utils.get_attrs(self, self.config_attrs)
+        group_data["name"] = self.name
+
+        post_data = json.dumps(group_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a Port Access VLAN Group.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a PortAccessVlanGroup object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {name: "/rest/v10.xx/system/port_access_vlan_groups/name"}
+        :return: PortAccessVlanGroup object.
+        """
+        group_arr = session.api.get_keys(response_data, cls.resource_uri_name)
+        name = group_arr[0]
+        return cls(session, name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a PortAccessVlanGroup object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the PortAccessVlanGroup
+            object.
+        """
+        index_pattern = re.compile(
+            r"(.*)port_access_vlan_groups/(?P<index>.+)"
+        )
+        name = index_pattern.match(uri).group("index")
+
+        group = cls(session, name)
+        return name, group
+
+    def __str__(self):
+        return "PortAccessVlanGroup name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific Port Access VLAN Group URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/rest/v10_16/api.py
+++ b/pyaoscx/rest/v10_16/api.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_16(API):
+    """
+    Represents a REST API Version 10.16. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2024, 12, 6)
+        self.version = "10.16"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            # If user does not pass value for other_config provide default
+            # value, it's needed for correct OSPF Area creation
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_16/interface.py
+++ b/pyaoscx/rest/v10_16/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.16.
+    """
+
+    pass

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,0 +1,160 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the Class and ClassEntry pyaoscx resource modules. The
+pyaoscx Session is mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from importlib import import_module
+
+from pyaoscx.class_entry import ClassEntry
+
+Class = getattr(import_module("pyaoscx.class"), "Class")
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["writable"]
+    api.compound_index_separator = ","
+    api.valid_depth = lambda depth: True
+    api.get_uri_from_data.side_effect = lambda data: list(data.values())
+    session.resource_prefix = "/rest/v10.16/"
+    session.proxy = None
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# Class
+# --------------------------------------------------------------------------
+def test_class_path():
+    session = make_session()
+    traffic_class = Class(session, "web", type="ipv4")
+    assert traffic_class.path == "system/classes/web,ipv4"
+    assert traffic_class.index == "web,ipv4"
+    assert traffic_class.name == "web"
+    assert traffic_class.type == "ipv4"
+
+
+def test_class_create_sends_name_and_type():
+    session = make_session()
+    traffic_class = Class(session, "web", type="ipv4")
+    traffic_class.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/classes"
+    assert post["data"]["name"] == "web"
+    assert post["data"]["type"] == "ipv4"
+
+
+def test_class_delete():
+    session = make_session()
+    traffic_class = Class(session, "web", type="ipv4")
+    traffic_class.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert deletes and deletes[0]["path"] == "system/classes/web,ipv4"
+
+
+def test_class_get_all():
+    session = make_session(
+        get_body={"web,ipv4": "/rest/v10.16/system/classes/web,ipv4"}
+    )
+    classes = Class.get_all(session)
+    assert "web,ipv4" in classes
+    assert classes["web,ipv4"].name == "web"
+    assert classes["web,ipv4"].type == "ipv4"
+
+
+# --------------------------------------------------------------------------
+# ClassEntry
+# --------------------------------------------------------------------------
+def make_parent(session):
+    return Class(session, "web", type="ipv4")
+
+
+def test_entry_path():
+    session = make_session()
+    parent = make_parent(session)
+    entry = ClassEntry(session, 10, parent)
+    assert entry.path == "system/classes/web,ipv4/cfg_entries/10"
+    assert entry.base_uri == "system/classes/web,ipv4/cfg_entries"
+    assert entry.sequence_number == 10
+
+
+def test_entry_create_sends_sequence_number_and_attrs():
+    session = make_session()
+    parent = make_parent(session)
+    entry = ClassEntry(
+        session, 10, parent, type="match", protocol=6, dst_ip="10.0.0.0/24"
+    )
+    entry.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/classes/web,ipv4/cfg_entries"
+    assert post["data"]["sequence_number"] == 10
+    assert post["data"]["type"] == "match"
+    assert post["data"]["protocol"] == 6
+    assert post["data"]["dst_ip"] == "10.0.0.0/24"
+
+
+def test_entry_get_configuration_selector():
+    session = make_session(get_body={"type": "match", "protocol": 6})
+    parent = make_parent(session)
+    entry = ClassEntry(session, 10, parent)
+    entry.get(selector="configuration")
+    assert entry.type == "match"
+    assert entry.protocol == 6
+
+
+def test_entry_get_all():
+    session = make_session(
+        get_body={"10": "/rest/v10.16/system/classes/web,ipv4/cfg_entries/10"}
+    )
+    parent = make_parent(session)
+    entries = ClassEntry.get_all(session, parent)
+    assert "10" in entries
+    assert entries["10"].sequence_number == "10"
+
+
+def test_entry_delete():
+    session = make_session()
+    parent = make_parent(session)
+    entry = ClassEntry(session, 10, parent)
+    entry.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert deletes[0]["path"] == "system/classes/web,ipv4/cfg_entries/10"

--- a/tests/test_port_access.py
+++ b/tests/test_port_access.py
@@ -1,0 +1,233 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the CaptivePortalProfile, PortAccessRole and
+PortAccessVlanGroup pyaoscx resource modules. The pyaoscx Session is mocked,
+so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.captive_portal_profile import CaptivePortalProfile
+from pyaoscx.port_access_role import PortAccessRole
+from pyaoscx.port_access_vlan_group import PortAccessVlanGroup
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["writable"]
+    api.valid_depth = lambda depth: True
+    api.get_uri_from_data.side_effect = lambda data: list(data.values())
+    session.resource_prefix = "/rest/v10.16/"
+    session.proxy = None
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# CaptivePortalProfile
+# --------------------------------------------------------------------------
+def test_cpp_path():
+    session = make_session()
+    cpp = CaptivePortalProfile(session, "cp1")
+    assert cpp.path == "system/captive_portal_profiles/cp1"
+    assert cpp.name == "cp1"
+
+
+def test_cpp_create_sends_name_and_attrs():
+    session = make_session()
+    cpp = CaptivePortalProfile(
+        session, "cp1", url="https://cp.example.com/login"
+    )
+    cpp.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/captive_portal_profiles"
+    assert post["data"]["name"] == "cp1"
+    assert post["data"]["url"] == "https://cp.example.com/login"
+
+
+def test_cpp_update_idempotent():
+    session = make_session(get_body={"url": "https://x", "url_hash_key": None})
+    cpp = CaptivePortalProfile(session, "cp1")
+    cpp.get(selector="writable")
+    assert cpp.update() is False
+    assert not [c for c in session.calls if c["method"] == "PUT"]
+
+
+def test_cpp_update_changed_uses_put():
+    session = make_session(get_body={"url": "https://x", "url_hash_key": None})
+    cpp = CaptivePortalProfile(session, "cp1")
+    cpp.get(selector="writable")
+    cpp.url = "https://y"
+    assert cpp.update() is True
+    puts = [c for c in session.calls if c["method"] == "PUT"]
+    assert len(puts) == 1
+    assert puts[0]["data"]["url"] == "https://y"
+
+
+def test_cpp_delete():
+    session = make_session()
+    cpp = CaptivePortalProfile(session, "cp1")
+    cpp.delete()
+    assert [c for c in session.calls if c["method"] == "DELETE"]
+
+
+def test_cpp_get_all():
+    body = {"cp1": "/rest/v10.16/system/captive_portal_profiles/cp1"}
+    session = make_session(get_body=body)
+    result = CaptivePortalProfile.get_all(session)
+    assert "cp1" in result
+
+
+def test_cpp_from_uri():
+    session = make_session()
+    uri = "/rest/v10.16/system/captive_portal_profiles/cp1"
+    name, obj = CaptivePortalProfile.from_uri(session, uri)
+    assert name == "cp1"
+    assert isinstance(obj, CaptivePortalProfile)
+
+
+# --------------------------------------------------------------------------
+# PortAccessVlanGroup
+# --------------------------------------------------------------------------
+def test_vg_path():
+    session = make_session()
+    vg = PortAccessVlanGroup(session, "vg1")
+    assert vg.path == "system/port_access_vlan_groups/vg1"
+
+
+def test_vg_create_sends_name_and_vlans():
+    session = make_session()
+    vg = PortAccessVlanGroup(session, "vg1", vlans=[10, 20])
+    vg.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/port_access_vlan_groups"
+    assert post["data"]["name"] == "vg1"
+    assert post["data"]["vlans"] == [10, 20]
+
+
+def test_vg_update_idempotent():
+    session = make_session(get_body={"vlans": [10, 20]})
+    vg = PortAccessVlanGroup(session, "vg1")
+    vg.get(selector="writable")
+    assert vg.update() is False
+
+
+def test_vg_update_changed_uses_put():
+    session = make_session(get_body={"vlans": [10]})
+    vg = PortAccessVlanGroup(session, "vg1")
+    vg.get(selector="writable")
+    vg.vlans = [10, 20]
+    assert vg.update() is True
+    puts = [c for c in session.calls if c["method"] == "PUT"]
+    assert puts[0]["data"]["vlans"] == [10, 20]
+
+
+def test_vg_delete():
+    session = make_session()
+    vg = PortAccessVlanGroup(session, "vg1")
+    vg.delete()
+    assert [c for c in session.calls if c["method"] == "DELETE"]
+
+
+# --------------------------------------------------------------------------
+# PortAccessRole
+# --------------------------------------------------------------------------
+def test_role_path():
+    session = make_session()
+    role = PortAccessRole(session, "role1")
+    assert role.path == "system/port_access_roles/role1"
+
+
+def test_role_create_sends_name_and_attrs():
+    session = make_session()
+    role = PortAccessRole(
+        session, "role1", description="r", vlan_mode="access", vlan_tag=10
+    )
+    role.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/port_access_roles"
+    assert post["data"]["name"] == "role1"
+    assert post["data"]["vlan_mode"] == "access"
+    assert post["data"]["vlan_tag"] == 10
+
+
+def test_role_update_idempotent():
+    session = make_session(
+        get_body={"description": "r", "vlan_mode": "access", "vlan_tag": 10}
+    )
+    role = PortAccessRole(session, "role1")
+    role.get(selector="writable")
+    assert role.update() is False
+
+
+def test_role_update_changed_uses_put():
+    session = make_session(
+        get_body={"description": "r", "vlan_mode": "access", "vlan_tag": 10}
+    )
+    role = PortAccessRole(session, "role1")
+    role.get(selector="writable")
+    role.description = "changed"
+    assert role.update() is True
+    puts = [c for c in session.calls if c["method"] == "PUT"]
+    assert puts[0]["data"]["description"] == "changed"
+
+
+def test_role_captive_portal_reference_roundtrip():
+    uri = "/rest/v10.16/system/captive_portal_profiles/cp1"
+    session = make_session(
+        get_body={"captive_portal_profile": {"cp1": uri}, "vlan_mode": None}
+    )
+    role = PortAccessRole(session, "role1")
+    role.get(selector="writable")
+    # unchanged reference -> idempotent
+    assert role.update() is False
+
+
+def test_role_delete():
+    session = make_session()
+    role = PortAccessRole(session, "role1")
+    role.delete()
+    assert [c for c in session.calls if c["method"] == "DELETE"]
+
+
+def test_role_get_all():
+    body = {"role1": "/rest/v10.16/system/port_access_roles/role1"}
+    session = make_session(get_body=body)
+    result = PortAccessRole.get_all(session)
+    assert "role1" in result

--- a/tests/test_port_access_policy.py
+++ b/tests/test_port_access_policy.py
@@ -1,0 +1,209 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the Port Access policy family resource modules
+(PortAccessGbp/Abp/Policy containers, their entries and action sets). The
+pyaoscx Session is mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.port_access_gbp import (
+    PortAccessGbp,
+    PortAccessGbpActionSet,
+    PortAccessGbpEntry,
+)
+from pyaoscx.port_access_abp import (
+    PortAccessAbp,
+    PortAccessAbpActionSet,
+)
+from pyaoscx.port_access_policy import (
+    PortAccessPolicy,
+    PortAccessPolicyActionSet,
+)
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["writable"]
+    api.valid_depth = lambda depth: True
+    api.get_uri_from_data.side_effect = lambda data: list(data.values())
+    session.resource_prefix = "/rest/v10.16/"
+    session.proxy = None
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# Container
+# --------------------------------------------------------------------------
+def test_container_path():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    assert gbp.path == "system/port_access_gbps/g1"
+    assert gbp.name == "g1"
+
+
+def test_container_create_sends_name():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    gbp.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/port_access_gbps"
+    assert post["data"]["name"] == "g1"
+
+
+def test_container_delete():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    gbp.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert deletes[0]["path"] == "system/port_access_gbps/g1"
+
+
+def test_container_get_all():
+    session = make_session(
+        get_body={"g1": "/rest/v10.16/system/port_access_gbps/g1"}
+    )
+    containers = PortAccessGbp.get_all(session)
+    assert "g1" in containers
+    assert containers["g1"].name == "g1"
+
+
+def test_container_base_uris():
+    session = make_session()
+    assert PortAccessAbp(session, "a").path == "system/port_access_abps/a"
+    assert (
+        PortAccessPolicy(session, "p").path == "system/port_access_policies/p"
+    )
+
+
+# --------------------------------------------------------------------------
+# Entry
+# --------------------------------------------------------------------------
+def test_entry_path():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    entry = PortAccessGbpEntry(session, 10, gbp)
+    assert entry.path == "system/port_access_gbps/g1/cfg_entries/10"
+    assert entry.base_uri == "system/port_access_gbps/g1/cfg_entries"
+    assert entry.sequence_number == 10
+
+
+def test_entry_create_sends_class_and_comment():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    entry = PortAccessGbpEntry(
+        session,
+        10,
+        gbp,
+        **{
+            "class": "/rest/v10.16/system/classes/c1,gbp-ipv4",
+            "comment": "x",
+        }
+    )
+    entry.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/port_access_gbps/g1/cfg_entries"
+    assert post["data"]["sequence_number"] == 10
+    assert post["data"]["class"] == "/rest/v10.16/system/classes/c1,gbp-ipv4"
+    assert post["data"]["comment"] == "x"
+
+
+def test_entry_get_all():
+    session = make_session(
+        get_body={
+            "10": ("/rest/v10.16/system/port_access_gbps/g1/cfg_entries/10")
+        }
+    )
+    gbp = PortAccessGbp(session, "g1")
+    entries = PortAccessGbpEntry.get_all(session, gbp)
+    assert "10" in entries
+    assert entries["10"].sequence_number == "10"
+
+
+def test_entry_delete():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    entry = PortAccessGbpEntry(session, 10, gbp)
+    entry.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert deletes[0]["path"] == "system/port_access_gbps/g1/cfg_entries/10"
+
+
+# --------------------------------------------------------------------------
+# Action set
+# --------------------------------------------------------------------------
+def test_action_set_path():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    entry = PortAccessGbpEntry(session, 10, gbp)
+    action = PortAccessGbpActionSet(session, entry)
+    assert action.path == (
+        "system/port_access_gbps/g1/cfg_entries/10/gbp_action_set"
+    )
+
+
+def test_action_set_create_sends_fields():
+    session = make_session()
+    gbp = PortAccessGbp(session, "g1")
+    entry = PortAccessGbpEntry(session, 10, gbp)
+    action = PortAccessGbpActionSet(session, entry, drop=True)
+    action.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == (
+        "system/port_access_gbps/g1/cfg_entries/10/gbp_action_set"
+    )
+    assert post["data"]["drop"] is True
+
+
+def test_action_set_update_idempotent():
+    session = make_session(get_body={"drop": True})
+    gbp = PortAccessGbp(session, "g1")
+    entry = PortAccessGbpEntry(session, 10, gbp)
+    action = PortAccessGbpActionSet(session, entry)
+    action.get()
+    action.drop = True
+    action.config_attrs = ["drop"]
+    assert action.update() is False
+
+
+def test_action_set_keys_per_family():
+    assert PortAccessGbpActionSet.action_key == "gbp_action_set"
+    assert PortAccessAbpActionSet.action_key == "abp_action_set"
+    assert PortAccessPolicyActionSet.action_key == "policy_action_set"


### PR DESCRIPTION
## Description

Add the resource classes needed to manage the full AOS-CX **port access (NAC)**
configuration.

**Top-level, `name`-indexed resources** (modelled on the existing
`AaaServerGroup` pattern — POST body includes `name`, PUT-based `update()`
reconcile):

- `CaptivePortalProfile` — `system/captive_portal_profiles`
- `PortAccessRole` — `system/port_access_roles`
- `PortAccessVlanGroup` — `system/port_access_vlan_groups`

**Traffic classes** (compound `name,type` index, with a child entry list):

- `Class` — `system/classes`
- `ClassEntry` — `system/classes/{name},{type}/cfg_entries`

**Three-level policy families** (container → entry → action set). A generic
base (`PortAccessPolicyContainer` / `PortAccessPolicyEntry` /
`PortAccessActionSet`) lives in `port_access_policy_common.py`, with thin family
modules layered on top:

- `PortAccessGbp` — `system/port_access_gbps` (group based policy)
- `PortAccessAbp` — `system/port_access_abps` (application based policy)
- `PortAccessPolicy` — `system/port_access_policies`

All classes are registered in `pyaoscx/api.py`.

The full `PortAccessRole` schema (e.g. `macsec_policy`,
`app_recognition_enable`, `poe_allocate_by_method`, `traffic_inspection_enable`,
`in_abp`, `ipfix_flow_monitor`) is only present at REST API **v10.16**, so this
PR also adds the `pyaoscx/rest/v10_16` API version module. (The same
`pyaoscx/rest/v10_16` module is introduced by the MACsec PR #75; whichever
merges first creates it and the other PR's copy becomes a no-op.)

## Testing

- `tests/test_port_access.py` — 19 offline unit tests (CaptivePortalProfile /
  PortAccessRole / PortAccessVlanGroup).
- `tests/test_class.py` — 9 offline unit tests (Class / ClassEntry).
- `tests/test_port_access_policy.py` — 13 offline unit tests (gbp / abp /
  policy containers, entries and action sets).
- All mocked-session, no switch required; `flake8` and
  `black --line-length 79` clean.
- Validated end-to-end against an AOS-CX 6300 (firmware FL.10.17, REST v10.16):
  full create / idempotent re-run / update / delete lifecycle for every
  resource, including the `PortAccessRole` references to
  `CaptivePortalProfile` and to the gbp/abp/policy containers, and the policy
  entries' traffic-class references.

Fixes #72

---

**Note on contribution guidelines:** `CONTRIBUTING.md` asks to target a
`development` branch, but this repository only has `master`, so this PR targets
`master`. It is linked to the required issue (#72).

Companion collection PR: aruba/aoscx-ansible-collection#154
