### PR TITLE
Add MACsec policy, MKA policy and keychain resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,10 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "MacsecPolicy": "macsec_policy",
+            "MkaPolicy": "mka_policy",
+            "Keychain": "keychain",
+            "KeychainKey": "keychain_key",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/keychain.py
+++ b/pyaoscx/keychain.py
@@ -1,0 +1,273 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class Keychain(PyaoscxModule):
+    """
+    Provide configuration management for Keychains on AOS-CX devices.
+    """
+
+    base_uri = "system/keychains"
+    resource_uri_name = "keychains"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Keychain and fill the object
+            with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "name" in data:
+            data.pop("name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(
+                self, data, "config_attrs", ["name", "keys"]
+            )
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all Keychains, and create a dictionary
+            containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the names as keys and the Keychain
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        keychains = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            indices, keychain = cls.from_uri(session, uri)
+            keychains[indices] = keychain
+
+        return keychains
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Keychain.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Keychain.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        keychain_data = utils.get_attrs(self, self.config_attrs)
+
+        if keychain_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(keychain_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = keychain_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Keychain. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        keychain_data = utils.get_attrs(self, self.config_attrs)
+        keychain_data["name"] = self.name
+
+        post_data = json.dumps(keychain_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a Keychain.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a Keychain object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {name: "/rest/v10.xx/system/keychains/name"}
+        :return: Keychain object.
+        """
+        keychain_arr = session.api.get_keys(
+            response_data, cls.resource_uri_name
+        )
+        name = keychain_arr[0]
+        return cls(session, name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a Keychain object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the Keychain object.
+        """
+        index_pattern = re.compile(r"(.*)keychains/(?P<index>.+)")
+        name = index_pattern.match(uri).group("index")
+
+        keychain = cls(session, name)
+        return name, keychain
+
+    def __str__(self):
+        return "Keychain name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific Keychain URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/keychain_key.py
+++ b/pyaoscx/keychain_key.py
@@ -1,0 +1,262 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class KeychainKey(PyaoscxModule):
+    """
+    Provide configuration management for Keychain Keys on AOS-CX devices.
+    """
+
+    collection_uri = "system/keychains/{name}/keys"
+    object_uri = collection_uri + "/{key_id}"
+    resource_name = "key_id"
+    indices = ["key_id"]
+
+    def __init__(self, session, key_id, parent_keychain, uri=None, **kwargs):
+        self.__keychain = parent_keychain
+        self.__key_id = key_id
+        self.session = session
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = self.object_uri.format(
+            name=self.__keychain.name, key_id=key_id
+        )
+        self.base_uri = self.collection_uri.format(name=self.__keychain.name)
+
+    @property
+    def key_id(self):
+        return self.__key_id
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a Keychain Key and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "key_id" in data:
+            data.pop("key_id")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["key_id"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, parent_keychain):
+        """
+        Perform a GET call to retrieve all Keys of a Keychain and create a
+            dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :param parent_keychain: Keychain object to which the keys belong.
+        :return: Dictionary containing the key IDs as keys and the KeychainKey
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=parent_keychain.name)
+
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        keys = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            key_id, key = cls.from_uri(session, parent_keychain, uri)
+            keys[key_id] = key
+
+        return keys
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing Keychain Key.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing Keychain Key.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        key_data = utils.get_attrs(self, self.config_attrs)
+
+        if key_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(key_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = key_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new Keychain Key. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        key_data = utils.get_attrs(self, self.config_attrs)
+        key_data["key_id"] = self.key_id
+
+        post_data = json.dumps(key_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a Keychain Key.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, parent_keychain, uri):
+        """
+        Create a KeychainKey object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param parent_keychain: Keychain object to which the key belongs.
+        :param uri: a String with a URI.
+        :return: tuple containing both the key ID and the KeychainKey object.
+        """
+        key_id = uri.split("/")[-1]
+        key = cls(session, key_id, parent_keychain)
+        return key_id, key
+
+    def __str__(self):
+        return "KeychainKey key_id:{0}".format(self.key_id)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific Keychain Key URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix,
+                self.path,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/macsec_policy.py
+++ b/pyaoscx/macsec_policy.py
@@ -1,0 +1,269 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class MacsecPolicy(PyaoscxModule):
+    """
+    Provide configuration management for MACsec Policies on AOS-CX devices.
+    """
+
+    base_uri = "system/macsec_policies"
+    resource_uri_name = "macsec_policies"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a MACsec Policy and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "name" in data:
+            data.pop("name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all MACsec Policies, and create a
+            dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the names as keys and the MacsecPolicy
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        policies = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            indices, policy = cls.from_uri(session, uri)
+            policies[indices] = policy
+
+        return policies
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing MACsec Policy.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing MACsec Policy.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        policy_data = utils.get_attrs(self, self.config_attrs)
+
+        if policy_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(policy_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = policy_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new MACsec Policy. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        policy_data = utils.get_attrs(self, self.config_attrs)
+        policy_data["name"] = self.name
+
+        post_data = json.dumps(policy_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a MACsec Policy.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create a MacsecPolicy object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {name: "/rest/v10.xx/system/macsec_policies/name"}
+        :return: MacsecPolicy object.
+        """
+        policy_arr = session.api.get_keys(response_data, cls.resource_uri_name)
+        name = policy_arr[0]
+        return cls(session, name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a MacsecPolicy object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the MacsecPolicy object.
+        """
+        index_pattern = re.compile(r"(.*)macsec_policies/(?P<index>.+)")
+        name = index_pattern.match(uri).group("index")
+
+        policy = cls(session, name)
+        return name, policy
+
+    def __str__(self):
+        return "MacsecPolicy name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific MACsec Policy URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/mka_policy.py
+++ b/pyaoscx/mka_policy.py
@@ -1,0 +1,269 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class MkaPolicy(PyaoscxModule):
+    """
+    Provide configuration management for MKA Policies on AOS-CX devices.
+    """
+
+    base_uri = "system/mka_policies"
+    resource_uri_name = "mka_policies"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an MKA Policy and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "name" in data:
+            data.pop("name")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all MKA Policies, and create a
+            dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object used to represent a logical
+            connection to the device.
+        :return: Dictionary containing the names as keys and the MkaPolicy
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        policies = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            indices, policy = cls.from_uri(session, uri)
+            policies[indices] = policy
+
+        return policies
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing MKA Policy.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing MKA Policy.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        policy_data = utils.get_attrs(self, self.config_attrs)
+
+        if policy_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(policy_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = policy_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new MKA Policy. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        policy_data = utils.get_attrs(self, self.config_attrs)
+        policy_data["name"] = self.name
+
+        post_data = json.dumps(policy_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete an MKA Policy.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_response(cls, session, response_data):
+        """
+        Create an MkaPolicy object given a response_data.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param response_data: The response must be a dictionary of the form:
+            {name: "/rest/v10.xx/system/mka_policies/name"}
+        :return: MkaPolicy object.
+        """
+        policy_arr = session.api.get_keys(response_data, cls.resource_uri_name)
+        name = policy_arr[0]
+        return cls(session, name)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an MkaPolicy object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the index and the MkaPolicy object.
+        """
+        index_pattern = re.compile(r"(.*)mka_policies/(?P<index>.+)")
+        name = index_pattern.match(uri).group("index")
+
+        policy = cls(session, name)
+        return name, policy
+
+    def __str__(self):
+        return "MkaPolicy name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific MKA Policy URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}/{2}".format(
+                self.session.resource_prefix,
+                self.base_uri,
+                self.name,
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/rest/v10_16/api.py
+++ b/pyaoscx/rest/v10_16/api.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_16(API):
+    """
+    Represents a REST API Version 10.16. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2024, 12, 6)
+        self.version = "10.16"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            # If user does not pass value for other_config provide default
+            # value, it's needed for correct OSPF Area creation
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_16/interface.py
+++ b/pyaoscx/rest/v10_16/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.16.
+    """
+
+    pass

--- a/tests/test_macsec.py
+++ b/tests/test_macsec.py
@@ -1,0 +1,235 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the MacsecPolicy, MkaPolicy, Keychain and KeychainKey
+pyaoscx resource modules. The pyaoscx Session is mocked, so no switch is
+required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.macsec_policy import MacsecPolicy
+from pyaoscx.mka_policy import MkaPolicy
+from pyaoscx.keychain import Keychain
+from pyaoscx.keychain_key import KeychainKey
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["writable"]
+    api.valid_depth = lambda depth: True
+    api.get_uri_from_data.side_effect = lambda data: list(data.values())
+    session.resource_prefix = "/rest/v10.16/"
+    session.proxy = None
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+# --------------------------------------------------------------------------
+# MacsecPolicy
+# --------------------------------------------------------------------------
+def test_macsec_path():
+    session = make_session()
+    mp = MacsecPolicy(session, "mp1")
+    assert mp.path == "system/macsec_policies/mp1"
+    assert mp.name == "mp1"
+
+
+def test_macsec_create_sends_name_and_nested():
+    session = make_session()
+    mp = MacsecPolicy(
+        session,
+        "mp1",
+        secure_mode="should-secure",
+        replay_window=100,
+        cipher_suites={"gcm_aes_256_enabled": True},
+    )
+    mp.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/macsec_policies"
+    assert post["data"]["name"] == "mp1"
+    assert post["data"]["secure_mode"] == "should-secure"
+    assert post["data"]["replay_window"] == 100
+    assert post["data"]["cipher_suites"] == {"gcm_aes_256_enabled": True}
+
+
+def test_macsec_update_idempotent():
+    session = make_session(
+        get_body={"secure_mode": "must-secure", "replay_window": 0}
+    )
+    mp = MacsecPolicy(session, "mp1")
+    mp.get(selector="writable")
+    assert mp.update() is False
+    assert not [c for c in session.calls if c["method"] == "PUT"]
+
+
+def test_macsec_update_changes():
+    session = make_session(
+        get_body={"secure_mode": "must-secure", "replay_window": 0}
+    )
+    mp = MacsecPolicy(session, "mp1")
+    mp.get(selector="writable")
+    mp.secure_mode = "should-secure"
+    assert mp.update() is True
+    put = [c for c in session.calls if c["method"] == "PUT"][0]
+    assert put["data"]["secure_mode"] == "should-secure"
+
+
+def test_macsec_delete():
+    session = make_session()
+    mp = MacsecPolicy(session, "mp1")
+    mp.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert deletes and deletes[0]["path"] == "system/macsec_policies/mp1"
+
+
+def test_macsec_get_all():
+    session = make_session(
+        get_body={"mp1": "/rest/v10.16/system/macsec_policies/mp1"}
+    )
+    result = MacsecPolicy.get_all(session)
+    assert "mp1" in result
+    assert isinstance(result["mp1"], MacsecPolicy)
+
+
+# --------------------------------------------------------------------------
+# MkaPolicy
+# --------------------------------------------------------------------------
+def test_mka_path():
+    session = make_session()
+    mka = MkaPolicy(session, "mka1")
+    assert mka.path == "system/mka_policies/mka1"
+
+
+def test_mka_create_sends_name_and_keychain():
+    uri = "/rest/v10.16/system/keychains/kc1"
+    session = make_session()
+    mka = MkaPolicy(
+        session, "mka1", mode="psk", transmit_interval=2, keychain=uri
+    )
+    mka.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/mka_policies"
+    assert post["data"]["name"] == "mka1"
+    assert post["data"]["mode"] == "psk"
+    assert post["data"]["keychain"] == uri
+
+
+def test_mka_update_idempotent():
+    session = make_session(get_body={"mode": "psk", "transmit_interval": 2})
+    mka = MkaPolicy(session, "mka1")
+    mka.get(selector="writable")
+    assert mka.update() is False
+
+
+# --------------------------------------------------------------------------
+# Keychain
+# --------------------------------------------------------------------------
+def test_keychain_path():
+    session = make_session()
+    kc = Keychain(session, "kc1")
+    assert kc.path == "system/keychains/kc1"
+    assert kc.name == "kc1"
+
+
+def test_keychain_create_sends_name():
+    session = make_session()
+    kc = Keychain(session, "kc1")
+    kc.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/keychains"
+    assert post["data"]["name"] == "kc1"
+
+
+def test_keychain_get_all():
+    session = make_session(
+        get_body={"kc1": "/rest/v10.16/system/keychains/kc1"}
+    )
+    result = Keychain.get_all(session)
+    assert "kc1" in result
+    assert isinstance(result["kc1"], Keychain)
+
+
+# --------------------------------------------------------------------------
+# KeychainKey
+# --------------------------------------------------------------------------
+def test_key_path():
+    session = make_session()
+    kc = Keychain(session, "kc1")
+    key = KeychainKey(session, 1, kc)
+    assert key.path == "system/keychains/kc1/keys/1"
+    assert key.base_uri == "system/keychains/kc1/keys"
+    assert key.key_id == 1
+
+
+def test_key_create_sends_key_id_and_attrs():
+    session = make_session()
+    kc = Keychain(session, "kc1")
+    key = KeychainKey(
+        session,
+        1,
+        kc,
+        auth_type="sha256",
+        auth_key="S3cretKey123",
+        send_start=1577836800,
+    )
+    key.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/keychains/kc1/keys"
+    assert post["data"]["key_id"] == 1
+    assert post["data"]["auth_type"] == "sha256"
+    assert post["data"]["auth_key"] == "S3cretKey123"
+
+
+def test_key_get_all():
+    session = make_session(
+        get_body={"1": "/rest/v10.16/system/keychains/kc1/keys/1"}
+    )
+    kc = Keychain(session, "kc1")
+    result = KeychainKey.get_all(session, kc)
+    assert "1" in result
+    assert isinstance(result["1"], KeychainKey)
+
+
+def test_key_delete():
+    session = make_session()
+    kc = Keychain(session, "kc1")
+    key = KeychainKey(session, 1, kc)
+    key.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert deletes and deletes[0]["path"] == "system/keychains/kc1/keys/1"


### PR DESCRIPTION
### Description

Adds pyaoscx SDK classes for the AOS-CX security resources required by the upcoming `arubanetworks.aoscx` MACsec / MKA / keychain Ansible modules:

- `MacsecPolicy` (`system/macsec_policies`, indexed by `name`) — scalar attributes plus nested `bypass` and `cipher_suites` dicts.
- `MkaPolicy` (`system/mka_policies`, indexed by `name`) — scalars, `keychain` URI reference, and write-only `cak` / `ckn`.
- `Keychain` (`system/keychains`, indexed by `name`).
- `KeychainKey` (nested `system/keychains/{name}/keys`, indexed by `key_id`) — child object of `Keychain`.

The four classes are registered in the `api.py` dispatch table (`module_names`).

### REST API v10.16

These resources require REST API v10.16 (HTTP 400 below v10.10), so this PR also adds `pyaoscx/rest/v10_16/` API support.

> [!NOTE]
> v10.16 support is also introduced by #73 (Port Access family). Whichever PR merges first, the other will be rebased to drop the duplicate `pyaoscx/rest/v10_16/` files.

### Tests

- `tests/test_macsec.py` — 16 offline unit tests (mocked session) covering paths, create payloads (including `name` / `key_id` and nested dicts), idempotent update, update changes, delete and `get_all` for all four classes.
- `flake8` + `black --line-length 79` clean.

### Validation

Validated live against an AOS-CX 6300 (FL.10.17.1001, REST v10.16): full create / read-back / update / delete lifecycle for all four classes, plus end-to-end exercise from the corresponding Ansible modules.

### Notes

- Per `CONTRIBUTING`, PRs should target `development`, but that branch does not exist in this repository, so this PR targets `master`.

Fixes #74

Companion collection PR: aruba/aoscx-ansible-collection#143
