### PR TITLE
Add NtpKey and NtpAssociation resource modules

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,8 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "NtpKey": "ntp_key",
+            "NtpAssociation": "ntp_association",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/ntp_association.py
+++ b/pyaoscx/ntp_association.py
@@ -1,0 +1,264 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class NtpAssociation(PyaoscxModule):
+    """
+    Provide configuration management for NTP associations (servers) on AOS-CX
+        devices. NTP associations are nested under a VRF and indexed by the
+        association address.
+    """
+
+    collection_uri = "system/vrfs/{name}/ntp_associations"
+    resource_uri_name = "ntp_associations"
+
+    indices = ["address"]
+
+    def __init__(self, session, vrf, address, uri=None, **kwargs):
+        self.session = session
+        # vrf is a Vrf object used as the parent in the URI path
+        self.vrf = vrf
+        self.address = address
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri.format(name=self.vrf.name)
+        self.path = "{0}/{1}".format(self.base_uri, self.address)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an NTP association and fill the
+            object with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        for index in self.indices + ["vrf"]:
+            if index in data:
+                data.pop(index)
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(
+                self, data, "config_attrs", self.indices + ["vrf"]
+            )
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, vrf):
+        """
+        Perform a GET call to retrieve all NTP associations under a VRF, and
+            create a dictionary containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object.
+        :param vrf: Vrf object the NTP associations belong to.
+        :return: Dictionary containing the address as keys and the
+            NtpAssociation objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        uri = cls.collection_uri.format(name=vrf.name)
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        associations = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for assoc_uri in uri_list:
+            index, assoc = cls.from_uri(session, vrf, assoc_uri)
+            associations[index] = assoc
+
+        return associations
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing NTP
+            association.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing NTP association.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        assoc_data = utils.get_attrs(self, self.config_attrs)
+
+        if assoc_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(assoc_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = assoc_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new NTP association. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        assoc_data = utils.get_attrs(self, self.config_attrs)
+        assoc_data["address"] = self.address
+        assoc_data["vrf"] = self.vrf.get_uri()
+
+        post_data = json.dumps(assoc_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete an NTP association.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, vrf, uri):
+        """
+        Create an NtpAssociation object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param vrf: Vrf object the NTP association belongs to.
+        :param uri: a String with a URI.
+        :return: tuple containing both the address and the NtpAssociation
+            object.
+        """
+        index_pattern = re.compile(r"(.*)ntp_associations/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        assoc = cls(session, vrf, index)
+        return index, assoc
+
+    def __str__(self):
+        return "NtpAssociation address:{0}".format(self.address)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific NTP association URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/pyaoscx/ntp_key.py
+++ b/pyaoscx/ntp_key.py
@@ -1,0 +1,252 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class NtpKey(PyaoscxModule):
+    """
+    Provide configuration management for NTP authentication keys on AOS-CX
+        devices. NTP keys live under system/ntp_keys and are indexed by
+        key_id.
+    """
+
+    base_uri = "system/ntp_keys"
+    resource_uri_name = "ntp_keys"
+
+    indices = ["key_id"]
+
+    def __init__(self, session, key_id, uri=None, **kwargs):
+        self.session = session
+        self.key_id = key_id
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.key_id)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for an NTP key and fill the object
+            with the incoming attributes.
+
+        :param depth: Integer deciding how many levels into the API JSON that
+            references will be returned.
+        :param selector: Alphanumeric option to select specific information to
+            return.
+        :return: Returns True if there is not an exception raised.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if not self.session.api.valid_depth(depth):
+            depths = self.session.api.valid_depths
+            raise Exception("ERROR: Depth should be {0}".format(depths))
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        if "key_id" in data:
+            data.pop("key_id")
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["key_id"])
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all NTP keys, and create a dictionary
+            containing them.
+
+        :param cls: Object's class.
+        :param session: pyaoscx.Session object.
+        :return: Dictionary containing the key_id as keys and the NtpKey
+            objects as values.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        keys = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for key_uri in uri_list:
+            index, key = cls.from_uri(session, key_uri)
+            keys[index] = key
+
+        return keys
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing NTP key.
+
+        :return: Boolean, True if object was created or modified.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing NTP key.
+
+        :return: True if Object was modified and a PUT request was made.
+        """
+        key_data = utils.get_attrs(self, self.config_attrs)
+
+        if key_data == self._original_attributes:
+            return False
+
+        post_data = json.dumps(key_data)
+
+        try:
+            response = self.session.request("PUT", self.path, data=post_data)
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = key_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new NTP key. Only returns if no
+            exception is raised.
+
+        :return: Boolean, True if entry was created.
+        """
+        key_data = utils.get_attrs(self, self.config_attrs)
+        key_data["key_id"] = self.key_id
+
+        post_data = json.dumps(key_data)
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=post_data
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete an NTP key.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create an NtpKey object given a URI.
+
+        :param cls: Class calling the method.
+        :param session: pyaoscx.Session object.
+        :param uri: a String with a URI.
+        :return: tuple containing both the key_id and the NtpKey object.
+        """
+        index_pattern = re.compile(r"(.*)ntp_keys/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        key = cls(session, int(index))
+        return index, key
+
+    def __str__(self):
+        return "NtpKey key_id:{0}".format(self.key_id)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        """
+        Method used to obtain the specific NTP key URI.
+
+        :return: Object's URI.
+        """
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        """
+        Method used to obtain correct object format for referencing inside
+            other objects.
+
+        :return: Object format depending on the API Version.
+        """
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        """
+        Return boolean with whether this object has been modified.
+        """
+        return self.__modified

--- a/tests/test_ntp.py
+++ b/tests/test_ntp.py
@@ -1,0 +1,175 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the NTP family pyaoscx resource modules (NtpKey and
+NtpAssociation). The pyaoscx Session is mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.ntp_key import NtpKey
+from pyaoscx.ntp_association import NtpAssociation
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = [
+        "configuration",
+        "writable",
+        "status",
+        "statistics",
+    ]
+    api.configurable_selectors = ["writable"]
+    api.valid_depth = lambda depth: True
+    api.get_uri_from_data.side_effect = lambda data: list(data.values())
+    session.resource_prefix = "/rest/v10.09/"
+    session.proxy = None
+
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        body = json.loads(data) if data else None
+        calls.append({"method": method, "path": path, "data": body})
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        if method in ("PUT", "DELETE"):
+            return make_response({}, 204)
+        return make_response({}, 200)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+def make_vrf(name="default"):
+    vrf = MagicMock()
+    vrf.name = name
+    vrf.get_uri.return_value = (
+        "/rest/v10.09/system/vrfs/{0}".format(name)
+    )
+    return vrf
+
+
+# --------------------------------------------------------------------------
+# NtpKey
+# --------------------------------------------------------------------------
+def test_key_path():
+    session = make_session()
+    key = NtpKey(session, 1)
+    assert key.path == "system/ntp_keys/1"
+    assert key.base_uri == "system/ntp_keys"
+    assert key.key_id == 1
+
+
+def test_key_create_sends_key_id():
+    session = make_session()
+    key = NtpKey(
+        session, 1, key_password="secret", key_type="md5", trust_enable=True
+    )
+    key.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/ntp_keys"
+    assert post["data"]["key_id"] == 1
+    assert post["data"]["key_type"] == "md5"
+    assert post["data"]["trust_enable"] is True
+
+
+def test_key_delete():
+    session = make_session()
+    key = NtpKey(session, 1)
+    key.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert deletes[0]["path"] == "system/ntp_keys/1"
+
+
+def test_key_get_all():
+    session = make_session(
+        get_body={"1": "/rest/v10.09/system/ntp_keys/1"}
+    )
+    keys = NtpKey.get_all(session)
+    assert "1" in keys
+    assert keys["1"].key_id == 1
+
+
+def test_key_get_pops_index():
+    session = make_session(get_body={"key_id": 5, "key_type": "sha1"})
+    key = NtpKey(session, 5)
+    key.get()
+    assert key.materialized is True
+    assert key.key_type == "sha1"
+
+
+# --------------------------------------------------------------------------
+# NtpAssociation
+# --------------------------------------------------------------------------
+def test_assoc_path():
+    session = make_session()
+    vrf = make_vrf()
+    assoc = NtpAssociation(session, vrf, "198.51.100.1")
+    assert assoc.base_uri == "system/vrfs/default/ntp_associations"
+    assert assoc.path == "system/vrfs/default/ntp_associations/198.51.100.1"
+    assert assoc.address == "198.51.100.1"
+
+
+def test_assoc_create_sends_address_and_vrf():
+    session = make_session()
+    vrf = make_vrf()
+    assoc = NtpAssociation(session, vrf, "198.51.100.1", prefer=True)
+    assoc.create()
+    post = [c for c in session.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/vrfs/default/ntp_associations"
+    assert post["data"]["address"] == "198.51.100.1"
+    assert post["data"]["vrf"] == "/rest/v10.09/system/vrfs/default"
+    assert post["data"]["prefer"] is True
+
+
+def test_assoc_delete():
+    session = make_session()
+    vrf = make_vrf()
+    assoc = NtpAssociation(session, vrf, "198.51.100.1")
+    assoc.delete()
+    deletes = [c for c in session.calls if c["method"] == "DELETE"]
+    assert (
+        deletes[0]["path"]
+        == "system/vrfs/default/ntp_associations/198.51.100.1"
+    )
+
+
+def test_assoc_get_all():
+    session = make_session(
+        get_body={
+            "198.51.100.1": (
+                "/rest/v10.09/system/vrfs/default/ntp_associations/"
+                "198.51.100.1"
+            )
+        }
+    )
+    vrf = make_vrf()
+    assocs = NtpAssociation.get_all(session, vrf)
+    assert "198.51.100.1" in assocs
+    assert assocs["198.51.100.1"].address == "198.51.100.1"
+
+
+def test_assoc_get_pops_index():
+    session = make_session(get_body={"address": "198.51.100.1", "vrf": "x"})
+    vrf = make_vrf()
+    assoc = NtpAssociation(session, vrf, "198.51.100.1")
+    assoc.get()
+    assert assoc.materialized is True
+    assert not hasattr(assoc, "address_extra")


### PR DESCRIPTION
## Summary

Add NTP family resource modules so the AOS-CX REST `system/ntp_keys` and
`system/vrfs/{vrf}/ntp_associations` endpoints are backed by first-class
pyaoscx classes.

- `NtpKey` (`pyaoscx/ntp_key.py`): indexed by `key_id`, manages NTP
  authentication keys. Standard get/get_all/create/update/delete/apply.
- `NtpAssociation` (`pyaoscx/ntp_association.py`): nested under a VRF, indexed
  by `address`, manages NTP server associations. POST body carries the VRF
  URI; optional `key_id` reference for authentication.
- Registered both in `api.py`.

## Tests

`tests/test_ntp.py` — 10 offline unit tests (paths, create payloads, delete,
get_all, index popping) with a mocked session. All pass.

Verified live on a 6300 (FL.10.17) at REST v10.09: key + association POST
201 / DELETE 204.

Companion collection PR: aruba/aoscx-ansible-collection#142



Fixes #78

