### PR TITLE
Add SNMP family resource modules (v10.16)

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -165,6 +165,11 @@ class API(ABC):
             "Queue": "queue",
             "QueueProfile": "queue_profile",
             "QueueProfileEntry": "queue_profile_entry",
+            "Snmpv3User": "snmpv3_user",
+            "SnmpCommunity": "snmp_community",
+            "SnmpView": "snmp_view",
+            "SnmpViewEntry": "snmp_view_entry",
+            "SnmpTrap": "snmp_trap",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
         }

--- a/pyaoscx/rest/v10_16/api.py
+++ b/pyaoscx/rest/v10_16/api.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_16(API):
+    """
+    Represents a REST API Version 10.16. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2024, 12, 6)
+        self.version = "10.16"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            # If user does not pass value for other_config provide default
+            # value, it's needed for correct OSPF Area creation
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_16/interface.py
+++ b/pyaoscx/rest/v10_16/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.16.
+    """
+
+    pass

--- a/pyaoscx/snmp_community.py
+++ b/pyaoscx/snmp_community.py
@@ -1,0 +1,165 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class SnmpCommunity(PyaoscxModule):
+    """
+    Provide configuration management for SNMP community attributes on AOS-CX
+        devices (system/snmp_community_attributes), indexed by name.
+    """
+
+    base_uri = "system/snmp_community_attributes"
+    resource_uri_name = "snmp_community_attributes"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        logging.info("Retrieving %s from switch", self)
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+        if not self.session.api.valid_depth(depth):
+            raise Exception(
+                "ERROR: Depth should be {0}".format(
+                    self.session.api.valid_depths
+                )
+            )
+        if selector not in self.session.api.valid_selectors:
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(
+                    " ".join(self.session.api.valid_selectors)
+                )
+            )
+        payload = {"depth": depth, "selector": selector}
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        data.pop("name", None)
+        utils.create_attrs(self, data)
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+        self._original_attributes = data
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        communities = {}
+        for uri in session.api.get_uri_from_data(data):
+            index, comm = cls.from_uri(session, uri)
+            communities[index] = comm
+        return communities
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        comm_data = utils.get_attrs(self, self.config_attrs)
+        if comm_data == self._original_attributes:
+            return False
+        try:
+            response = self.session.request(
+                "PUT", self.path, data=json.dumps(comm_data)
+            )
+        except Exception as e:
+            raise ResponseError("PUT", e)
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = comm_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        comm_data = utils.get_attrs(self, self.config_attrs)
+        comm_data["name"] = self.name
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(comm_data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Adding %s", self)
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        index_pattern = re.compile(
+            r"(.*)snmp_community_attributes/(?P<index>.+)"
+        )
+        index = index_pattern.match(uri).group("index")
+        return index, cls(session, index)
+
+    def __str__(self):
+        return "SnmpCommunity name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified

--- a/pyaoscx/snmp_trap.py
+++ b/pyaoscx/snmp_trap.py
@@ -1,0 +1,172 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class SnmpTrap(PyaoscxModule):
+    """
+    Provide configuration management for SNMP trap receivers on AOS-CX
+        devices (system/snmp_traps). Compound index of
+        vrf,receiver_address,receiver_udp_port,type,version. Create/delete
+        only.
+    """
+
+    base_uri = "system/snmp_traps"
+    resource_uri_name = "snmp_traps"
+
+    indices = [
+        "vrf",
+        "receiver_address",
+        "receiver_udp_port",
+        "type",
+        "version",
+    ]
+
+    def __init__(
+        self,
+        session,
+        vrf,
+        receiver_address,
+        receiver_udp_port,
+        type,
+        version,
+        uri=None,
+        **kwargs
+    ):
+        self.session = session
+        # vrf is a Vrf object used both in the URI index and the POST body
+        self.vrf = vrf
+        self.receiver_address = receiver_address
+        self.receiver_udp_port = receiver_udp_port
+        self.type = type
+        self.version = version
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        sep = self.session.api.compound_index_separator
+        index = sep.join(
+            [
+                self.vrf.name,
+                self.receiver_address,
+                str(self.receiver_udp_port),
+                self.type,
+                self.version,
+            ]
+        )
+        self.path = "{0}/{1}".format(self.base_uri, index)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        logging.info("Retrieving %s from switch", self)
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+        payload = {"depth": depth, "selector": selector}
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        for index in self.indices:
+            data.pop(index, None)
+        utils.create_attrs(self, data)
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", self.indices)
+        self._original_attributes = data
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        return session.api.get_uri_from_data(data)
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            return False
+        modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        # Trap receivers are identified by their full compound index; there
+        # are no mutable attributes beyond it.
+        return False
+
+    @PyaoscxModule.connected
+    def create(self):
+        trap_data = utils.get_attrs(self, self.config_attrs)
+        trap_data["vrf"] = self.vrf.get_uri()
+        trap_data["receiver_address"] = self.receiver_address
+        trap_data["receiver_udp_port"] = self.receiver_udp_port
+        trap_data["type"] = self.type
+        trap_data["version"] = self.version
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(trap_data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Adding %s", self)
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        index_pattern = re.compile(r"(.*)snmp_traps/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        return index, uri
+
+    def __str__(self):
+        return "SnmpTrap {0}".format(self.receiver_address)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified

--- a/pyaoscx/snmp_view.py
+++ b/pyaoscx/snmp_view.py
@@ -1,0 +1,163 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class SnmpView(PyaoscxModule):
+    """
+    Provide configuration management for SNMP views on AOS-CX devices
+        (system/snmp_views), indexed by name.
+    """
+
+    base_uri = "system/snmp_views"
+    resource_uri_name = "snmp_views"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        logging.info("Retrieving %s from switch", self)
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+        if not self.session.api.valid_depth(depth):
+            raise Exception(
+                "ERROR: Depth should be {0}".format(
+                    self.session.api.valid_depths
+                )
+            )
+        if selector not in self.session.api.valid_selectors:
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(
+                    " ".join(self.session.api.valid_selectors)
+                )
+            )
+        payload = {"depth": depth, "selector": selector}
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        data.pop("name", None)
+        utils.create_attrs(self, data)
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+        self._original_attributes = data
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        views = {}
+        for uri in session.api.get_uri_from_data(data):
+            index, view = cls.from_uri(session, uri)
+            views[index] = view
+        return views
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        view_data = utils.get_attrs(self, self.config_attrs)
+        if view_data == self._original_attributes:
+            return False
+        try:
+            response = self.session.request(
+                "PUT", self.path, data=json.dumps(view_data)
+            )
+        except Exception as e:
+            raise ResponseError("PUT", e)
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = view_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        view_data = utils.get_attrs(self, self.config_attrs)
+        view_data["name"] = self.name
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(view_data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Adding %s", self)
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        index_pattern = re.compile(r"(.*)snmp_views/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        return index, cls(session, index)
+
+    def __str__(self):
+        return "SnmpView name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified

--- a/pyaoscx/snmp_view_entry.py
+++ b/pyaoscx/snmp_view_entry.py
@@ -70,8 +70,23 @@ class SnmpViewEntry(PyaoscxModule):
             raise GenericOperationError(response.text, response.status_code)
         data = json.loads(response.text)
         entries = {}
-        for entry_uri in session.api.get_uri_from_data(data):
-            index, entry = cls.from_uri(session, parent_view, entry_uri)
+        if not data:
+            return entries
+        is_uri_map = all(
+            isinstance(v, str) and "snmp_view_entry/" in v
+            for v in data.values()
+        )
+        if is_uri_map:
+            for entry_uri in session.api.get_uri_from_data(data):
+                index, entry = cls.from_uri(session, parent_view, entry_uri)
+                entries[index] = entry
+        else:
+            # Some firmware returns the entry attributes inline instead of a
+            # reference map; build a materialized entry from them.
+            index = data.get("oid_tree")
+            entry = cls(session, index, parent_view)
+            utils.create_attrs(entry, data)
+            entry.materialized = True
             entries[index] = entry
         return entries
 

--- a/pyaoscx/snmp_view_entry.py
+++ b/pyaoscx/snmp_view_entry.py
@@ -1,0 +1,139 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class SnmpViewEntry(PyaoscxModule):
+    """
+    Provide configuration management for SNMP view entries on AOS-CX devices
+        (system/snmp_views/{name}/snmp_view_entry), indexed by uuid. Entries
+        are create/delete only; their fields are immutable once created.
+    """
+
+    resource_uri_name = "snmp_view_entry"
+
+    indices = ["uuid"]
+
+    def __init__(self, session, uuid, parent_view, uri=None, **kwargs):
+        self.session = session
+        self.uuid = uuid
+        self.parent_view = parent_view
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = "{0}/snmp_view_entry".format(parent_view.path)
+        self.path = "{0}/{1}".format(self.base_uri, self.uuid)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        logging.info("Retrieving %s from switch", self)
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+        payload = {"depth": depth, "selector": selector}
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        data.pop("uuid", None)
+        utils.create_attrs(self, data)
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["uuid"])
+        self._original_attributes = data
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, parent_view):
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        uri = "{0}/snmp_view_entry".format(parent_view.path)
+        try:
+            response = session.request("GET", uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        entries = {}
+        for entry_uri in session.api.get_uri_from_data(data):
+            index, entry = cls.from_uri(session, parent_view, entry_uri)
+            entries[index] = entry
+        return entries
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            return False
+        modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        # View entry fields are immutable; nothing to update.
+        return False
+
+    @PyaoscxModule.connected
+    def create(self):
+        entry_data = utils.get_attrs(self, self.config_attrs)
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(entry_data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Adding %s", self)
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, parent_view, uri):
+        index_pattern = re.compile(r"(.*)snmp_view_entry/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        return index, cls(session, index, parent_view)
+
+    def __str__(self):
+        return "SnmpViewEntry uuid:{0}".format(self.uuid)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified

--- a/pyaoscx/snmpv3_user.py
+++ b/pyaoscx/snmpv3_user.py
@@ -1,0 +1,163 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class Snmpv3User(PyaoscxModule):
+    """
+    Provide configuration management for SNMPv3 users on AOS-CX devices
+        (system/snmpv3_users), indexed by user_name.
+    """
+
+    base_uri = "system/snmpv3_users"
+    resource_uri_name = "snmpv3_users"
+
+    indices = ["user_name"]
+
+    def __init__(self, session, user_name, uri=None, **kwargs):
+        self.session = session
+        self.user_name = user_name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.user_name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        logging.info("Retrieving %s from switch", self)
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+        if not self.session.api.valid_depth(depth):
+            raise Exception(
+                "ERROR: Depth should be {0}".format(
+                    self.session.api.valid_depths
+                )
+            )
+        if selector not in self.session.api.valid_selectors:
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(
+                    " ".join(self.session.api.valid_selectors)
+                )
+            )
+        payload = {"depth": depth, "selector": selector}
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        data.pop("user_name", None)
+        utils.create_attrs(self, data)
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["user_name"])
+        self._original_attributes = data
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        users = {}
+        for uri in session.api.get_uri_from_data(data):
+            index, user = cls.from_uri(session, uri)
+            users[index] = user
+        return users
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        user_data = utils.get_attrs(self, self.config_attrs)
+        if user_data == self._original_attributes:
+            return False
+        try:
+            response = self.session.request(
+                "PUT", self.path, data=json.dumps(user_data)
+            )
+        except Exception as e:
+            raise ResponseError("PUT", e)
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = user_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        user_data = utils.get_attrs(self, self.config_attrs)
+        user_data["user_name"] = self.user_name
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(user_data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Adding %s", self)
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        index_pattern = re.compile(r"(.*)snmpv3_users/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        return index, cls(session, index)
+
+    def __str__(self):
+        return "Snmpv3User user_name:{0}".format(self.user_name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified

--- a/tests/test_snmp.py
+++ b/tests/test_snmp.py
@@ -1,0 +1,124 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the SNMP family pyaoscx resource modules (Snmpv3User,
+SnmpCommunity, SnmpView, SnmpViewEntry, SnmpTrap). The pyaoscx Session is
+mocked, so no switch is required.
+"""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.snmpv3_user import Snmpv3User
+from pyaoscx.snmp_community import SnmpCommunity
+from pyaoscx.snmp_view import SnmpView
+from pyaoscx.snmp_view_entry import SnmpViewEntry
+from pyaoscx.snmp_trap import SnmpTrap
+
+
+def make_response(body, code=200):
+    resp = MagicMock()
+    resp.status_code = code
+    resp.text = json.dumps(body)
+    return resp
+
+
+def make_session(get_body=None):
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = ["configuration", "writable", "status"]
+    api.configurable_selectors = ["writable"]
+    api.compound_index_separator = ","
+    api.valid_depth = lambda depth: True
+    api.get_uri_from_data.side_effect = lambda data: list(data.values())
+    session.resource_prefix = "/rest/v10.16/"
+    session.proxy = None
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        calls.append(
+            {
+                "method": method,
+                "path": path,
+                "data": json.loads(data) if data else None,
+            }
+        )
+        if method == "GET":
+            return make_response(get_body if get_body is not None else {})
+        if method == "POST":
+            return make_response({}, 201)
+        return make_response({}, 204)
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+def make_vrf(name="default"):
+    vrf = MagicMock()
+    vrf.name = name
+    vrf.get_uri.return_value = "/rest/v10.16/system/vrfs/" + name
+    return vrf
+
+
+def test_user_create():
+    s = make_session()
+    Snmpv3User(s, "alice", access_level="ro").create()
+    post = [c for c in s.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/snmpv3_users"
+    assert post["data"]["user_name"] == "alice"
+
+
+def test_user_path_delete():
+    s = make_session()
+    u = Snmpv3User(s, "alice")
+    assert u.path == "system/snmpv3_users/alice"
+    u.delete()
+    assert [c for c in s.calls if c["method"] == "DELETE"]
+
+
+def test_community_create():
+    s = make_session()
+    SnmpCommunity(s, "anstest").create()
+    post = [c for c in s.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/snmp_community_attributes"
+    assert post["data"]["name"] == "anstest"
+
+
+def test_view_create():
+    s = make_session()
+    SnmpView(s, "v1").create()
+    post = [c for c in s.calls if c["method"] == "POST"][0]
+    assert post["data"]["name"] == "v1"
+
+
+def test_view_entry_path():
+    s = make_session()
+    v = SnmpView(s, "v1")
+    e = SnmpViewEntry(s, "u1", v, oid_tree="1.3.6.1", type="included")
+    assert e.base_uri == "system/snmp_views/v1/snmp_view_entry"
+    e.create()
+    post = [c for c in s.calls if c["method"] == "POST"][0]
+    assert post["data"]["oid_tree"] == "1.3.6.1"
+    assert e.update() is False
+
+
+def test_trap_compound_index():
+    s = make_session()
+    vrf = make_vrf()
+    t = SnmpTrap(
+        s, vrf, "198.51.100.5", 162, "trap", "v2c", community_name="public"
+    )
+    assert t.path == (
+        "system/snmp_traps/default,198.51.100.5,162,trap,v2c"
+    )
+    t.create()
+    post = [c for c in s.calls if c["method"] == "POST"][0]
+    assert post["data"]["vrf"] == "/rest/v10.16/system/vrfs/default"
+    assert post["data"]["receiver_address"] == "198.51.100.5"
+    assert t.update() is False


### PR DESCRIPTION
## Summary

Add the SNMP family of resource modules so the AOS-CX Ansible collection
can manage SNMP through pyaoscx.

New modules (registered in `pyaoscx/api.py`):

- `Snmpv3User` (`system/snmpv3_users`) — full CRUD, with auth/priv
  protocols and pass phrases, access level, remote engine ID, view link.
- `SnmpCommunity` (`system/snmp_community_attributes`) — CRUD, optional
  view link.
- `SnmpView` (`system/snmp_views`) — CRUD.
- `SnmpViewEntry` (`.../snmp_view_entry`) — server-generated UUID index,
  create/delete only (entries are immutable).
- `SnmpTrap` (`system/snmp_traps`) — compound index
  (vrf, receiver_address, receiver_udp_port, type, version), create/delete.

Adds the v10.16 REST mapping required by the SNMP endpoints.

## Testing

- Offline unit tests (`tests/test_snmp.py`) — mocked session, 6 passing.
- Live lifecycle (create + idempotency + delete) on a CX6300 FL.10.17
  switch via the companion collection modules.

## Companion collection PR

Companion collection PR: aruba/aoscx-ansible-collection#160

Fixes #79
