### PR TITLE
Add User resource module

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -167,6 +167,7 @@ class API(ABC):
             "QueueProfileEntry": "queue_profile_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
+            "User": "user",
         }
         if name not in module_names:
             raise ParameterError(

--- a/pyaoscx/user.py
+++ b/pyaoscx/user.py
@@ -1,0 +1,160 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class User(PyaoscxModule):
+    """
+    Provide configuration management for local users on AOS-CX devices
+        (system/users), indexed by name.
+    """
+
+    base_uri = "system/users"
+    resource_uri_name = "users"
+
+    indices = ["name"]
+
+    def __init__(self, session, name, uri=None, **kwargs):
+        self.session = session
+        self.name = name
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = "{0}/{1}".format(self.base_uri, self.name)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        logging.info("Retrieving %s from switch", self)
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+        if not self.session.api.valid_depth(depth):
+            raise Exception(
+                "ERROR: Depth should be {0}".format(
+                    self.session.api.valid_depths
+                )
+            )
+        if selector not in self.session.api.valid_selectors:
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(
+                    " ".join(self.session.api.valid_selectors)
+                )
+            )
+        payload = {"depth": depth, "selector": selector}
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        data.pop("name", None)
+        utils.create_attrs(self, data)
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", ["name"])
+        self._original_attributes = data
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+        data = json.loads(response.text)
+        users = {}
+        for uri in session.api.get_uri_from_data(data):
+            index, user = cls.from_uri(session, uri)
+            users[index] = user
+        return users
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        user_data = utils.get_attrs(self, self.config_attrs)
+        try:
+            response = self.session.request(
+                "PUT", self.path, data=json.dumps(user_data)
+            )
+        except Exception as e:
+            raise ResponseError("PUT", e)
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Updating %s", self)
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        user_data = utils.get_attrs(self, self.config_attrs)
+        user_data["name"] = self.name
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(user_data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Adding %s", self)
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        index_pattern = re.compile(r"(.*)users/(?P<index>.+)")
+        index = index_pattern.match(uri).group("index")
+        return index, cls(session, index)
+
+    def __str__(self):
+        return "User name:{0}".format(self.name)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,63 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""Offline unit tests for the User pyaoscx resource module."""
+
+import json
+
+from unittest.mock import MagicMock
+
+from pyaoscx.user import User
+
+
+def make_session():
+    session = MagicMock()
+    api = session.api
+    api.default_depth = 1
+    api.default_selector = "writable"
+    api.valid_depths = [0, 1, 2, 3, 4]
+    api.valid_selectors = ["configuration", "writable", "status"]
+    api.configurable_selectors = ["writable"]
+    api.valid_depth = lambda depth: True
+    session.resource_prefix = "/rest/v10.09/"
+    calls = []
+
+    def request(method, path, params=None, data=None):
+        calls.append(
+            {
+                "method": method,
+                "path": path,
+                "data": json.loads(data) if data else None,
+            }
+        )
+        resp = MagicMock()
+        resp.status_code = 201 if method == "POST" else 200
+        if method == "DELETE":
+            resp.status_code = 204
+        resp.text = json.dumps({})
+        return resp
+
+    session.request.side_effect = request
+    session.calls = calls
+    return session
+
+
+def test_create():
+    s = make_session()
+    grp = "/rest/v10.09/system/user_groups/operators"
+    User(s, "netadmin", password="x", user_group=grp).create()
+    post = [c for c in s.calls if c["method"] == "POST"][0]
+    assert post["path"] == "system/users"
+    assert post["data"]["name"] == "netadmin"
+
+
+def test_path():
+    s = make_session()
+    u = User(s, "netadmin")
+    assert u.path == "system/users/netadmin"
+
+
+def test_delete():
+    s = make_session()
+    User(s, "netadmin").delete()
+    assert [c for c in s.calls if c["method"] == "DELETE"]


### PR DESCRIPTION
## Summary

Add a `User` resource class so the AOS-CX Ansible collection can manage
local users through pyaoscx.

- `User` (`system/users`, indexed by `name`) — password, authorized_keys,
  user_group reference. Standard get/create/update/delete/apply lifecycle.
  Registered in `pyaoscx/api.py`.

Works on REST API v10.09.

## Testing

- Offline unit tests (`tests/test_user.py`) — mocked session, 3 passing.
- Live create + update + delete on a CX6300 FL.10.17 switch.

## Companion collection PR

Companion collection PR: aruba/aoscx-ansible-collection#162

Fixes #82
