### PR TITLE
Add support for the latest REST version

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -28,6 +28,16 @@ class API(ABC):
         """
         version_name = "v" + target_version.replace(".", "_")
 
+        if target_version == "latest":
+            # Resolve "latest" to the newest shipped API version.
+            from pkgutil import iter_modules
+            from pyaoscx import rest
+            versions = sorted(
+                m.name for m in iter_modules(rest.__path__)
+                if m.name.startswith("v10_")
+            )
+            version_name = versions[-1] if versions else "v10_09"
+
         try:
             # Import the appropriate API class based on the name.
             target_module = "pyaoscx.rest.{0}.api".format(version_name)

--- a/pyaoscx/session.py
+++ b/pyaoscx/session.py
@@ -42,12 +42,14 @@ class Session:
             else {"http": proxy, "https": proxy}
         )
         self.scheme = "https"
-        self.version_path = "rest/v{0}/".format(self.api)
+        _prefix = "latest" if str(api) == "latest" \
+            else "v{0}".format(self.api)
+        self.version_path = "rest/{0}/".format(_prefix)
 
         # TODO: remove base_url once all modules use the internal
         # request methods
-        self.base_url = "https://{0}/rest/v{1}/".format(self.ip, self.api)
-        self.resource_prefix = "/rest/v{0}/".format(self.api)
+        self.base_url = "https://{0}/rest/{1}/".format(self.ip, _prefix)
+        self.resource_prefix = "/rest/{0}/".format(_prefix)
         self.__username = self.__password = ""
 
     def __eq__(self, other):
@@ -84,7 +86,7 @@ class Session:
 
         # From base url retrieve the ip address and the version
         url_pattern = re.compile(
-            r"https://(?P<ip_address>.+)/rest/v(?P<version>.+)/"
+            r"https://(?P<ip_address>.+)/rest/v?(?P<version>.+)/"
         )
         match = url_pattern.match(base_url)
         if match:


### PR DESCRIPTION
Fixes #92

Adds support for opening a session with the special version "latest". The connection uses the switch /rest/latest/ endpoint and the API class resolves to the newest shipped version, so the SDK can talk to switches exposing newer REST versions without pinning. Verified live on a CX6300 (FL.10.17): session open, app_recognition and ipfix reachable.
