### PR TITLE
Add RADIUS dynamic authorization classes

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -156,6 +156,8 @@ class API(ABC):
             "StaticRoute": "static_route",
             "StaticNexthop": "static_nexthop",
             "PoEInterface": "poe_interface",
+            "RadiusDynamicAuthorization": "radius_dynamic_authorization",
+            "RadiusDynamicAuthorizationClient": "radius_dynamic_authorization_client",
             "LLDPNeighbor": "lldp_neighbor",
             "Mac": "mac",
             "StaticMac": "static_mac",

--- a/pyaoscx/radius_dynamic_authorization.py
+++ b/pyaoscx/radius_dynamic_authorization.py
@@ -1,0 +1,136 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusDynamicAuthorization(PyaoscxModule):
+    """
+    Provide configuration management for the global RADIUS dynamic
+        authorization (Change of Authorization) settings. These live as the
+        radius_dynamic_authorization attribute of the system resource.
+    """
+
+    base_uri = "system"
+    resource_uri_name = "system"
+
+    indices = []
+
+    _attr = "radius_dynamic_authorization"
+
+    def __init__(self, session, uri=None, **kwargs):
+        self.session = session
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        self.radius_dynamic_authorization = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.path = self.base_uri
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve the global dynamic authorization
+            settings from the system resource.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+
+        payload = {"attributes": self._attr, "depth": depth}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+        value = data.get(self._attr, {})
+        self.radius_dynamic_authorization = value
+        if self._attr not in self.config_attrs:
+            self.config_attrs.append(self._attr)
+        self._original_attributes = {self._attr: dict(value)}
+        self.materialized = True
+        return True
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Apply the configured values with a PUT to the system resource.
+        """
+        modified = self.update()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to the global settings.
+        """
+        data = {self._attr: self.radius_dynamic_authorization}
+
+        if data == self._original_attributes:
+            return False
+
+        try:
+            response = self.session.request(
+                "PUT", self.path, data=json.dumps(data)
+            )
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = {
+            self._attr: dict(self.radius_dynamic_authorization)
+        }
+        self.__modified = True
+        return True
+
+    def create(self):
+        return self.update()
+
+    def delete(self):
+        pass
+
+    @classmethod
+    def get_all(cls, session):
+        return {}
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        return cls(session, uri=uri)
+
+    def __str__(self):
+        return "RADIUS Dynamic Authorization"
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified

--- a/pyaoscx/radius_dynamic_authorization_client.py
+++ b/pyaoscx/radius_dynamic_authorization_client.py
@@ -1,0 +1,235 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusDynamicAuthorizationClient(PyaoscxModule):
+    """
+    Provide configuration management for RADIUS dynamic authorization clients
+        (Change of Authorization clients). They live under a VRF in
+        radius_dynamic_authorization_clients and are indexed by the compound
+        key address and connection_type.
+    """
+
+    collection_uri = (
+        "system/vrfs/{vrf}/radius_dynamic_authorization_clients"
+    )
+
+    indices = ["address", "connection_type"]
+
+    def __init__(
+        self, session, vrf, address, connection_type, uri=None, **kwargs
+    ):
+        self.session = session
+        if hasattr(vrf, "name"):
+            vrf = vrf.name
+        self.__vrf = vrf
+        self.address = address
+        self.connection_type = connection_type
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        sep = self.session.api.compound_index_separator
+        self.base_uri = self.collection_uri.format(vrf=vrf)
+        self.index = "{0}{1}{2}".format(
+            self.address, sep, self.connection_type
+        )
+        self.path = "{0}/{1}".format(self.base_uri, self.index)
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a client and fill the object
+            with the incoming attributes.
+        """
+        logging.info("Retrieving %s from switch", self)
+
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        for index in self.indices:
+            data.pop(index, None)
+
+        utils.create_attrs(self, data)
+
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", self.indices)
+
+        self._original_attributes = data
+
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, vrf):
+        """
+        Perform a GET call to retrieve all clients of a VRF.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+
+        if hasattr(vrf, "name"):
+            vrf = vrf.name
+        base_uri = cls.collection_uri.format(vrf=vrf)
+
+        try:
+            response = session.request("GET", base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+
+        clients = {}
+        uri_list = session.api.get_uri_from_data(data)
+        for uri in uri_list:
+            index, client = cls.from_uri(session, vrf, uri)
+            clients[index] = client
+
+        return clients
+
+    @PyaoscxModule.connected
+    def apply(self):
+        """
+        Main method used to either create or update an existing client.
+        """
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        """
+        Perform a PUT call to apply changes to an existing client.
+        """
+        client_data = utils.get_attrs(self, self.config_attrs)
+
+        if client_data == self._original_attributes:
+            return False
+
+        try:
+            response = self.session.request(
+                "PUT", self.path, data=json.dumps(client_data)
+            )
+        except Exception as e:
+            raise ResponseError("PUT", e)
+
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = client_data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new client.
+        """
+        client_data = utils.get_attrs(self, self.config_attrs)
+        client_data["address"] = self.address
+        client_data["connection_type"] = self.connection_type
+        client_data["vrf"] = "{0}system/vrfs/{1}".format(
+            self.session.resource_prefix, self.__vrf
+        )
+
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(client_data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Adding %s", self)
+
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        """
+        Perform DELETE call to delete a client.
+        """
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, vrf, uri):
+        """
+        Create a RadiusDynamicAuthorizationClient object given a URI.
+        """
+        index_pattern = re.compile(
+            r"(.*)radius_dynamic_authorization_clients/(?P<index>.+)"
+        )
+        index = index_pattern.match(uri).group("index")
+        sep = session.api.compound_index_separator
+        address, connection_type = index.split(sep)
+        client = cls(session, vrf, address, connection_type)
+        return index, client
+
+    def __str__(self):
+        return "RADIUS Dynamic Authorization Client {0} {1}".format(
+            self.address, self.connection_type
+        )
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @property
+    def modified(self):
+        return self.__modified


### PR DESCRIPTION
Fixes #94

Adds RadiusDynamicAuthorization (global Change of Authorization settings on the system resource) and RadiusDynamicAuthorizationClient (per-VRF clients, compound index address/connection_type), registered in the API module table. Verified live on a CX6300 (FL.10.17, REST latest): get, create, update, idempotency and delete.

Companion collection PR: aruba/aoscx-ansible-collection#179
