### PR TITLE
Keep TunnelEndpoint network_id as a multi-VNI map

### DIFF
--- a/pyaoscx/tunnel_endpoint.py
+++ b/pyaoscx/tunnel_endpoint.py
@@ -76,11 +76,11 @@ class TunnelEndpoint(PyaoscxModule):
         # this is common for all PyaoscxModule derived classes
         self._get_and_copy_data(depth, selector, self.indices)
         self.materialized = True
-        vni_urls = self.network_id
-        vni_url = vni_urls[next(iter(vni_urls))]
-        Vni = self.session.api.get_module_class(self.session, "Vni")
-        _, vni = Vni.from_uri(self.session, self.interface, vni_url)
-        self.network_id = vni
+        # A Tunnel Endpoint can flood several VNIs, so network_id is kept as
+        # the full {vni_key: uri} map instead of being collapsed to a single
+        # VNI object. Callers that need VNI objects can resolve the URIs.
+        if not isinstance(self.network_id, dict):
+            self.network_id = {}
         return True
 
     @classmethod
@@ -129,6 +129,24 @@ class TunnelEndpoint(PyaoscxModule):
             return self.update()
         return self.create()
 
+    def _network_id_payload(self):
+        """
+        Serialize the network_id attribute into the {vni_key: uri} map the
+            REST API expects. Accepts a single VNI object, a list/tuple/set of
+            VNI objects, or an already-built {vni_key: uri} map.
+
+        :return: Dictionary in {vni_key: uri} form.
+        """
+        nid = self.network_id
+        if isinstance(nid, dict):
+            return dict(nid)
+        if isinstance(nid, (list, tuple, set)):
+            payload = {}
+            for vni in nid:
+                payload.update(self.session.api.get_index(vni))
+            return payload
+        return self.session.api.get_index(nid)
+
     @PyaoscxModule.connected
     def update(self):
         """
@@ -138,7 +156,7 @@ class TunnelEndpoint(PyaoscxModule):
             made.
         """
         tep_data = {}
-        tep_data["network_id"] = self.network_id.get_info_format()
+        tep_data["network_id"] = self._network_id_payload()
         self.__modified = self._put_data(tep_data)
         return self.__modified
 
@@ -154,7 +172,7 @@ class TunnelEndpoint(PyaoscxModule):
         tep_data = {}
         tep_data["destination"] = self.destination
         tep_data["interface"] = self.interface.get_info_format()
-        tep_data["network_id"] = self.network_id.get_info_format()
+        tep_data["network_id"] = self._network_id_payload()
         tep_data["origin"] = self.origin
         tep_data["vrf"] = self.vrf.get_info_format()
 

--- a/tests/test_tunnel_endpoint.py
+++ b/tests/test_tunnel_endpoint.py
@@ -1,0 +1,105 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for pyaoscx.tunnel_endpoint.TunnelEndpoint.
+
+A Tunnel Endpoint (TEP) is indexed by (vrf, origin, destination) and can flood
+several VNIs at once through its ``network_id`` map. These tests cover the
+serialization of ``network_id`` (single VNI, list of VNIs, or an existing
+{vni_key: uri} map) and the fact that ``get`` keeps the full map instead of
+collapsing it to a single VNI.
+"""
+
+from pyaoscx.tunnel_endpoint import TunnelEndpoint
+
+
+class FakeVni:
+    def __init__(self, key, uri):
+        self.key = key
+        self.uri = uri
+
+
+class FakeVrf:
+    def __init__(self, name="default"):
+        self.name = name
+
+    def get_info_format(self):
+        return {"vrfs": "/rest/latest/system/vrfs/" + self.name}
+
+
+class FakeInterface:
+    percents_name = "vxlan1"
+
+    def get_info_format(self):
+        return {"interfaces": "/rest/latest/system/interfaces/vxlan1"}
+
+
+class FakeApi:
+    def get_index(self, vni):
+        return {vni.key: vni.uri}
+
+    def get_module(self, session, module, name):
+        return FakeVrf(name)
+
+
+class FakeSession:
+    def __init__(self):
+        self.api = FakeApi()
+
+
+def make_tep(network_id):
+    return TunnelEndpoint(
+        FakeSession(),
+        FakeInterface(),
+        network_id,
+        "9.9.9.9",
+        origin="static",
+        vrf=FakeVrf("default"),
+    )
+
+
+def test_payload_single_vni():
+    tep = make_tep(FakeVni("vxlan_vni,206", "u206"))
+    assert tep._network_id_payload() == {"vxlan_vni,206": "u206"}
+
+
+def test_payload_list_of_vnis():
+    tep = make_tep(
+        [FakeVni("vxlan_vni,206", "u206"), FakeVni("vxlan_vni,207", "u207")]
+    )
+    assert tep._network_id_payload() == {
+        "vxlan_vni,206": "u206",
+        "vxlan_vni,207": "u207",
+    }
+
+
+def test_payload_existing_map_returned_as_copy():
+    original = {"vxlan_vni,206": "u206"}
+    tep = make_tep(original)
+    payload = tep._network_id_payload()
+    assert payload == original
+    assert payload is not original
+
+
+def test_get_preserves_network_id_map():
+    tep = make_tep(FakeVni("vxlan_vni,206", "u206"))
+    expected = {"vxlan_vni,206": "u206", "vxlan_vni,207": "u207"}
+
+    def fake_copy(depth, selector, indices):
+        tep.network_id = dict(expected)
+
+    tep._get_and_copy_data = fake_copy
+    tep.get()
+    assert tep.network_id == expected
+
+
+def test_get_defaults_to_empty_map_when_absent():
+    tep = make_tep(FakeVni("vxlan_vni,206", "u206"))
+
+    def fake_copy(depth, selector, indices):
+        tep.network_id = None
+
+    tep._get_and_copy_data = fake_copy
+    tep.get()
+    assert tep.network_id == {}


### PR DESCRIPTION
Fixes #104

Companion collection PR: aruba/aoscx-ansible-collection#212

## Summary

A Tunnel Endpoint (TEP) is indexed by `(vrf, origin, destination)` and can flood **several VNIs at once** through its `network_id` map. The previous implementation collapsed `network_id` to a single VNI object on `get()` and only serialized one VNI on `create()`/`update()`, which silently dropped the other VNIs of a shared TEP.

## Changes

- `get()` now keeps `network_id` as the full `{vni_key: uri}` map instead of collapsing it to a single VNI.
- New `_network_id_payload()` helper serializes a single VNI, a list of VNIs, or an existing `{vni_key: uri}` map into the form the REST API expects.
- `create()` and `update()` use the helper.
- Adds offline unit tests (`tests/test_tunnel_endpoint.py`).

## Testing

- Offline unit tests pass (`pytest tests/test_tunnel_endpoint.py`).
- Validated live on a CX 6300 (FL.10.17, REST `latest`): a static VTEP peer shared by two VNIs is preserved when removed from one of them.
