### PR TITLE
Add RADIUS dynamic authorization proxy resource classes

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -167,6 +167,9 @@ class API(ABC):
             "QueueProfileEntry": "queue_profile_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
+            "RadiusDynauthProxyServer": "radius_dynauth_proxy_server",
+            "RadiusDynauthProxyClientGroup": "radius_dynauth_proxy_client_group",
+            "RadiusDynauthProxyProfile": "radius_dynauth_proxy_profile",
         }
         if name not in module_names:
             raise ParameterError(

--- a/pyaoscx/radius_dynauth_proxy_client_group.py
+++ b/pyaoscx/radius_dynauth_proxy_client_group.py
@@ -1,0 +1,118 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusDynauthProxyClientGroup(PyaoscxModule):
+    """
+    Provide configuration management for RADIUS dynamic authorization proxy
+        client groups on AOS-CX devices. They live under
+        system/radius_dynauth_proxy_client_groups and are indexed by the group
+        name. The ``clients`` attribute is a map of numeric ids to RADIUS
+        dynamic authorization client URIs.
+    """
+
+    collection_uri = "system/radius_dynauth_proxy_client_groups"
+    object_uri = collection_uri + "/{group_name}"
+
+    indices = ["group_name"]
+    resource_uri_name = "radius_dynauth_proxy_client_groups"
+
+    def __init__(self, session, group_name, **kwargs):
+        self.session = session
+        self.group_name = group_name
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri
+        self.path = self.object_uri.format(group_name=self.group_name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a proxy client group and fill
+            the object with the incoming attributes.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all proxy client groups.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+        collection = {}
+        for uri in data.values():
+            name, group = cls.from_uri(session, uri)
+            collection[name] = group
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a RadiusDynauthProxyClientGroup object given a URI.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        return name, cls(session, name)
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new proxy client group. Only the group
+            name is configurable at creation; clients are applied through
+            update().
+        """
+        data = {"group_name": self.group_name}
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        return self.path
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/radius_dynauth_proxy_profile.py
+++ b/pyaoscx/radius_dynauth_proxy_profile.py
@@ -1,0 +1,118 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusDynauthProxyProfile(PyaoscxModule):
+    """
+    Provide configuration management for RADIUS dynamic authorization proxy
+        profiles on AOS-CX devices. They live under
+        system/radius_dynauth_proxy_profiles and are indexed by the profile
+        name. A profile ties together a proxy client group and a proxy server
+        (referenced by URI) within a VRF.
+    """
+
+    collection_uri = "system/radius_dynauth_proxy_profiles"
+    object_uri = collection_uri + "/{profile_name}"
+
+    indices = ["profile_name"]
+    resource_uri_name = "radius_dynauth_proxy_profiles"
+
+    def __init__(self, session, profile_name, **kwargs):
+        self.session = session
+        self.profile_name = profile_name
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri
+        self.path = self.object_uri.format(profile_name=self.profile_name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a proxy profile and fill the
+            object with the incoming attributes.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all proxy profiles.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+        collection = {}
+        for uri in data.values():
+            name, profile = cls.from_uri(session, uri)
+            collection[name] = profile
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a RadiusDynauthProxyProfile object given a URI.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        return name, cls(session, name)
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new proxy profile. Only the profile
+            name is configurable at creation; the remaining attributes are
+            applied through update().
+        """
+        data = {"profile_name": self.profile_name}
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        return self.path
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/radius_dynauth_proxy_server.py
+++ b/pyaoscx/radius_dynauth_proxy_server.py
@@ -1,0 +1,202 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+import re
+
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+from pyaoscx.exceptions.response_error import ResponseError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusDynauthProxyServer(PyaoscxModule):
+    """
+    Provide configuration management for RADIUS dynamic authorization proxy
+        servers on AOS-CX devices. They live under a VRF in
+        radius_dynauth_proxy_servers and are indexed by the compound key
+        address, port and port_type.
+    """
+
+    collection_uri = "system/vrfs/{vrf}/radius_dynauth_proxy_servers"
+
+    indices = ["address", "port", "port_type"]
+
+    def __init__(
+        self, session, vrf, address, port, port_type="udp", uri=None,
+        **kwargs
+    ):
+        self.session = session
+        if hasattr(vrf, "name"):
+            vrf = vrf.name
+        self.__vrf = vrf
+        self.address = address
+        self.port = port
+        self.port_type = port_type
+        self._uri = uri
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        sep = self.session.api.compound_index_separator
+        self.base_uri = self.collection_uri.format(vrf=vrf)
+        self.index = "{0}{1}{2}{1}{3}".format(
+            self.address, sep, self.port, self.port_type
+        )
+        self.path = "{0}/{1}".format(self.base_uri, self.index)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a proxy server and fill the
+            object with the incoming attributes.
+        """
+        logging.info("Retrieving %s from switch", self)
+        depth = depth or self.session.api.default_depth
+        selector = selector or self.session.api.default_selector
+
+        if selector not in self.session.api.valid_selectors:
+            selectors = " ".join(self.session.api.valid_selectors)
+            raise Exception(
+                "ERROR: Selector should be one of {0}".format(selectors)
+            )
+
+        payload = {"depth": depth, "selector": selector}
+        try:
+            response = self.session.request("GET", self.path, params=payload)
+        except Exception as e:
+            raise ResponseError("GET", e)
+
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+        for index in self.indices:
+            data.pop(index, None)
+        utils.create_attrs(self, data)
+        if selector in self.session.api.configurable_selectors:
+            utils.set_config_attrs(self, data, "config_attrs", self.indices)
+        self._original_attributes = data
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session, vrf):
+        """
+        Perform a GET call to retrieve all proxy servers of a VRF.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        if hasattr(vrf, "name"):
+            vrf = vrf.name
+        base_uri = cls.collection_uri.format(vrf=vrf)
+        try:
+            response = session.request("GET", base_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+        servers = {}
+        for uri in session.api.get_uri_from_data(data):
+            index, server = cls.from_uri(session, vrf, uri)
+            servers[index] = server
+        return servers
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            modified = self.update()
+        else:
+            modified = self.create()
+        self.__modified = modified
+        return modified
+
+    @PyaoscxModule.connected
+    def update(self):
+        data = utils.get_attrs(self, self.config_attrs)
+        if data == self._original_attributes:
+            return False
+        try:
+            response = self.session.request(
+                "PUT", self.path, data=json.dumps(data)
+            )
+        except Exception as e:
+            raise ResponseError("PUT", e)
+        if not utils._response_ok(response, "PUT"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Updating %s", self)
+        self._original_attributes = data
+        return True
+
+    @PyaoscxModule.connected
+    def create(self):
+        data = utils.get_attrs(self, self.config_attrs)
+        data["address"] = self.address
+        data["port"] = self.port
+        data["port_type"] = self.port_type
+        data["vrf"] = "{0}system/vrfs/{1}".format(
+            self.session.resource_prefix, self.__vrf
+        )
+        try:
+            response = self.session.request(
+                "POST", self.base_uri, data=json.dumps(data)
+            )
+        except Exception as e:
+            raise ResponseError("POST", e)
+        if not utils._response_ok(response, "POST"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Adding %s", self)
+        self.get()
+        return True
+
+    @PyaoscxModule.connected
+    def delete(self):
+        try:
+            response = self.session.request("DELETE", self.path)
+        except Exception as e:
+            raise ResponseError("DELETE", e)
+        if not utils._response_ok(response, "DELETE"):
+            raise GenericOperationError(response.text, response.status_code)
+        logging.info("SUCCESS: Deleting %s", self)
+        utils.delete_attrs(self, self.config_attrs)
+
+    @classmethod
+    def from_uri(cls, session, vrf, uri):
+        index_pattern = re.compile(
+            r"(.*)radius_dynauth_proxy_servers/(?P<index>.+)"
+        )
+        index = index_pattern.match(uri).group("index")
+        sep = session.api.compound_index_separator
+        address, port, port_type = index.split(sep)
+        server = cls(session, vrf, address, port, port_type)
+        return index, server
+
+    def __str__(self):
+        return "RADIUS Dynauth Proxy Server {0} {1} {2}".format(
+            self.address, self.port, self.port_type
+        )
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        if self._uri is None:
+            self._uri = "{0}{1}".format(
+                self.session.resource_prefix, self.path
+            )
+        return self._uri
+
+    @PyaoscxModule.deprecated
+    def get_info_format(self):
+        return self.session.api.get_index(self)
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/tests/test_radius_dynauth_proxy.py
+++ b/tests/test_radius_dynauth_proxy.py
@@ -1,0 +1,80 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the RADIUS dynamic authorization proxy SDK classes:
+RadiusDynauthProxyServer, RadiusDynauthProxyClientGroup and
+RadiusDynauthProxyProfile.
+"""
+
+from unittest.mock import MagicMock
+
+from pyaoscx.radius_dynauth_proxy_server import RadiusDynauthProxyServer
+from pyaoscx.radius_dynauth_proxy_client_group import (
+    RadiusDynauthProxyClientGroup,
+)
+from pyaoscx.radius_dynauth_proxy_profile import RadiusDynauthProxyProfile
+
+
+def make_session():
+    session = MagicMock()
+    session.api.compound_index_separator = ","
+    return session
+
+
+def test_server_index_and_path():
+    server = RadiusDynauthProxyServer(
+        make_session(), "default", "192.0.2.30", 3799, "udp"
+    )
+    assert server.base_uri == "system/vrfs/default/radius_dynauth_proxy_servers"
+    assert server.path.endswith(
+        "radius_dynauth_proxy_servers/192.0.2.30,3799,udp"
+    )
+    assert RadiusDynauthProxyServer.indices == [
+        "address", "port", "port_type"
+    ]
+
+
+def test_server_from_uri():
+    session = make_session()
+    uri = (
+        "/rest/latest/system/vrfs/default/radius_dynauth_proxy_servers/"
+        "192.0.2.30,3799,udp"
+    )
+    index, server = RadiusDynauthProxyServer.from_uri(session, "default", uri)
+    assert index == "192.0.2.30,3799,udp"
+    assert server.address == "192.0.2.30"
+    assert server.port == "3799"
+    assert server.port_type == "udp"
+
+
+def test_client_group_index_and_create_payload():
+    group = RadiusDynauthProxyClientGroup(MagicMock(), "coa-grp")
+    assert group.base_uri == "system/radius_dynauth_proxy_client_groups"
+    assert group.path.endswith("radius_dynauth_proxy_client_groups/coa-grp")
+    captured = {}
+    group._post_data = lambda data: captured.update(data) or True
+    assert group.create() is True
+    assert captured == {"group_name": "coa-grp"}
+
+
+def test_profile_index_and_create_payload():
+    profile = RadiusDynauthProxyProfile(MagicMock(), "coa-proxy")
+    assert profile.base_uri == "system/radius_dynauth_proxy_profiles"
+    assert profile.path.endswith("radius_dynauth_proxy_profiles/coa-proxy")
+    captured = {}
+    profile._post_data = lambda data: captured.update(data) or True
+    assert profile.create() is True
+    assert captured == {"profile_name": "coa-proxy"}
+
+
+def test_from_uri_names():
+    session = MagicMock()
+    _, group = RadiusDynauthProxyClientGroup.from_uri(
+        session, "/x/radius_dynauth_proxy_client_groups/g1"
+    )
+    assert group.group_name == "g1"
+    _, profile = RadiusDynauthProxyProfile.from_uri(
+        session, "/x/radius_dynauth_proxy_profiles/p1"
+    )
+    assert profile.profile_name == "p1"


### PR DESCRIPTION
Fixes #106

Companion collection PR: aruba/aoscx-ansible-collection#217
## Summary

Adds the RADIUS dynamic authorization (Change of Authorization) proxy resource classes: `RadiusDynauthProxyServer` (compound index address, port, port_type under a VRF), `RadiusDynauthProxyClientGroup` (referencing CoA clients through a numeric id to URI map) and `RadiusDynauthProxyProfile` (tying a client group and a server within a VRF). Registered in `api.py`.

## Testing

- Offline unit tests pass.
- Validated live on a CX 6300 (FL.10.17, REST `latest`): create / idempotency / update / delete of the full server + client group + profile graph.
