### PR TITLE
Add RADIUS proxy resource classes

### DIFF
--- a/pyaoscx/api.py
+++ b/pyaoscx/api.py
@@ -167,6 +167,8 @@ class API(ABC):
             "QueueProfileEntry": "queue_profile_entry",
             "TunnelEndpoint": "tunnel_endpoint",
             "Vni": "vni",
+            "RadiusProxyClientGroup": "radius_proxy_client_group",
+            "RadiusProxyProfile": "radius_proxy_profile",
         }
         if name not in module_names:
             raise ParameterError(

--- a/pyaoscx/radius_proxy_client_group.py
+++ b/pyaoscx/radius_proxy_client_group.py
@@ -1,0 +1,118 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusProxyClientGroup(PyaoscxModule):
+    """
+    Provide configuration management for RADIUS proxy client groups on AOS-CX
+        devices. They live under system/radius_proxy_client_groups and are
+        indexed by the group name. The ``clients`` attribute is a map of NAS
+        client addresses to their per-client settings (connection type and
+        shared secret).
+    """
+
+    collection_uri = "system/radius_proxy_client_groups"
+    object_uri = collection_uri + "/{group_name}"
+
+    indices = ["group_name"]
+    resource_uri_name = "radius_proxy_client_groups"
+
+    def __init__(self, session, group_name, **kwargs):
+        self.session = session
+        self.group_name = group_name
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri
+        self.path = self.object_uri.format(group_name=self.group_name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a proxy client group and fill
+            the object with the incoming attributes.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all proxy client groups.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+        collection = {}
+        for uri in data.values():
+            name, group = cls.from_uri(session, uri)
+            collection[name] = group
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a RadiusProxyClientGroup object given a URI.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        return name, cls(session, name)
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new proxy client group. Only the group
+            name is configurable at creation; clients are applied through
+            update().
+        """
+        data = {"group_name": self.group_name}
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        return self.path
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/pyaoscx/radius_proxy_profile.py
+++ b/pyaoscx/radius_proxy_profile.py
@@ -1,0 +1,117 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+import json
+import logging
+
+from pyaoscx.exceptions.response_error import ResponseError
+from pyaoscx.exceptions.generic_op_error import GenericOperationError
+
+from pyaoscx.utils import util as utils
+
+from pyaoscx.pyaoscx_module import PyaoscxModule
+
+
+class RadiusProxyProfile(PyaoscxModule):
+    """
+    Provide configuration management for RADIUS proxy profiles on AOS-CX
+        devices. They live under system/radius_proxy_profiles and are indexed
+        by the profile name. A profile ties together a proxy client group and
+        an AAA server group (both referenced by URI) within a VRF.
+    """
+
+    collection_uri = "system/radius_proxy_profiles"
+    object_uri = collection_uri + "/{profile_name}"
+
+    indices = ["profile_name"]
+    resource_uri_name = "radius_proxy_profiles"
+
+    def __init__(self, session, profile_name, **kwargs):
+        self.session = session
+        self.profile_name = profile_name
+        self.config_attrs = []
+        self.materialized = False
+        self._original_attributes = {}
+        utils.set_creation_attrs(self, **kwargs)
+        self.__modified = False
+        self.base_uri = self.collection_uri
+        self.path = self.object_uri.format(profile_name=self.profile_name)
+
+    @property
+    def modified(self):
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def get(self, depth=None, selector=None):
+        """
+        Perform a GET call to retrieve data for a proxy profile and fill the
+            object with the incoming attributes.
+        """
+        logging.info("Retrieving %s from switch", self)
+        self._get_and_copy_data(depth, selector, self.indices)
+        self.materialized = True
+        return True
+
+    @classmethod
+    def get_all(cls, session):
+        """
+        Perform a GET call to retrieve all proxy profiles.
+        """
+        logging.info("Retrieving all %s data from switch", cls.__name__)
+        try:
+            response = session.request("GET", cls.collection_uri)
+        except Exception as e:
+            raise ResponseError("GET", e)
+        if not utils._response_ok(response, "GET"):
+            raise GenericOperationError(response.text, response.status_code)
+
+        data = json.loads(response.text)
+        collection = {}
+        for uri in data.values():
+            name, profile = cls.from_uri(session, uri)
+            collection[name] = profile
+        return collection
+
+    @classmethod
+    def from_uri(cls, session, uri):
+        """
+        Create a RadiusProxyProfile object given a URI.
+        """
+        name = uri.rstrip("/").split("/")[-1]
+        return name, cls(session, name)
+
+    @PyaoscxModule.connected
+    def apply(self):
+        if self.materialized:
+            return self.update()
+        return self.create()
+
+    @PyaoscxModule.connected
+    def update(self):
+        data = utils.get_attrs(self, self.config_attrs)
+        self.__modified = self._put_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def create(self):
+        """
+        Perform a POST call to create a new proxy profile. Only the profile
+            name is configurable at creation; the remaining attributes are
+            applied through update().
+        """
+        data = {"profile_name": self.profile_name}
+        self.__modified = self._post_data(data)
+        return self.__modified
+
+    @PyaoscxModule.connected
+    def delete(self):
+        self._send_data(self.path, None, "DELETE", "Delete")
+        utils.delete_attrs(self, self.config_attrs)
+
+    @PyaoscxModule.deprecated
+    def get_uri(self):
+        return self.path
+
+    @PyaoscxModule.deprecated
+    def was_modified(self):
+        return self.modified

--- a/tests/test_radius_proxy.py
+++ b/tests/test_radius_proxy.py
@@ -1,0 +1,45 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+"""
+Offline unit tests for the RADIUS proxy SDK classes:
+RadiusProxyClientGroup and RadiusProxyProfile.
+"""
+
+from unittest.mock import MagicMock
+
+from pyaoscx.radius_proxy_client_group import RadiusProxyClientGroup
+from pyaoscx.radius_proxy_profile import RadiusProxyProfile
+
+
+def test_client_group_index_and_create_payload():
+    group = RadiusProxyClientGroup(MagicMock(), "nas-grp")
+    assert group.base_uri == "system/radius_proxy_client_groups"
+    assert group.path.endswith("radius_proxy_client_groups/nas-grp")
+    assert RadiusProxyClientGroup.indices == ["group_name"]
+    captured = {}
+    group._post_data = lambda data: captured.update(data) or True
+    assert group.create() is True
+    assert captured == {"group_name": "nas-grp"}
+
+
+def test_profile_index_and_create_payload():
+    profile = RadiusProxyProfile(MagicMock(), "radius-proxy")
+    assert profile.base_uri == "system/radius_proxy_profiles"
+    assert profile.path.endswith("radius_proxy_profiles/radius-proxy")
+    captured = {}
+    profile._post_data = lambda data: captured.update(data) or True
+    assert profile.create() is True
+    assert captured == {"profile_name": "radius-proxy"}
+
+
+def test_from_uri_names():
+    session = MagicMock()
+    _, group = RadiusProxyClientGroup.from_uri(
+        session, "/x/radius_proxy_client_groups/g1"
+    )
+    assert group.group_name == "g1"
+    _, profile = RadiusProxyProfile.from_uri(
+        session, "/x/radius_proxy_profiles/p1"
+    )
+    assert profile.profile_name == "p1"


### PR DESCRIPTION
Fixes #107

Companion collection PR: aruba/aoscx-ansible-collection#218
## Summary

Adds the RADIUS proxy resource classes: `RadiusProxyClientGroup` (downstream NAS clients defined inline as {address: {connection_type, secret_key}}) and `RadiusProxyProfile` (tying a client group and an AAA server group within a VRF). Registered in `api.py`.

## Testing

- Offline unit tests pass.
- Validated live on a CX 6300 (FL.10.17, REST `latest`): create / idempotency / update / delete.
