### PR TITLE
Add REST API version modules for v10.13 and v10.16

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Notable Changes
+
+* Added REST API version modules for v10.13 and v10.16, enabling sessions and
+  resources that require those API versions (for example, IPFIX, Traffic
+  Insight, MACsec policies, and client probe profiles).
+
 # 2.6.0
 
 ## Notable Changes

--- a/pyaoscx/rest/v10_13/__init__.py
+++ b/pyaoscx/rest/v10_13/__init__.py
@@ -1,0 +1,2 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0

--- a/pyaoscx/rest/v10_13/api.py
+++ b/pyaoscx/rest/v10_13/api.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_13(API):
+    """
+    Represents a REST API Version 10.13. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2023, 10, 27)
+        self.version = "10.13"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            # If user does not pass value for other_config provide default
+            # value, it's needed for correct OSPF Area creation
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_13/interface.py
+++ b/pyaoscx/rest/v10_13/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.13.
+    """
+
+    pass

--- a/pyaoscx/rest/v10_16/__init__.py
+++ b/pyaoscx/rest/v10_16/__init__.py
@@ -1,0 +1,2 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0

--- a/pyaoscx/rest/v10_16/api.py
+++ b/pyaoscx/rest/v10_16/api.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from datetime import date
+
+from pyaoscx.api import API
+
+
+class v10_16(API):
+    """
+    Represents a REST API Version 10.16. It keeps all the information needed
+        for the version and methods related to it.
+    """
+
+    def __init__(self):
+        self.release_date = date(2024, 10, 25)
+        self.version = "10.16"
+        self.default_selector = "writable"
+        self.default_depth = 1
+        self.default_facts_depth = 2
+        self.default_subsystem_facts_depth = 4
+        self.default_data_planes_facts_depth = 6
+        self.valid_selectors = [
+            "configuration",
+            "status",
+            "statistics",
+            "writable",
+        ]
+        self.configurable_selectors = ["writable"]
+        self.compound_index_separator = ","
+        self.valid_depths = [0, 1, 2, 3, 4, 6]
+
+    def _create_ospf_area(self, module_class, session, index_id, **kwargs):
+        if "other_config" not in kwargs:
+            # If user does not pass value for other_config provide default
+            # value, it's needed for correct OSPF Area creation
+            kwargs["other_config"] = {
+                "stub_default_cost": 1,
+                "stub_metric_type": "metric_non_comparable",
+            }
+        return module_class(session, index_id, **kwargs)

--- a/pyaoscx/rest/v10_16/interface.py
+++ b/pyaoscx/rest/v10_16/interface.py
@@ -1,0 +1,12 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# Apache License 2.0
+
+from pyaoscx.interface import Interface as AbstractInterface
+
+
+class Interface(AbstractInterface):
+    """
+    Provide configuration management for Interface for Version 10.16.
+    """
+
+    pass


### PR DESCRIPTION
Adds `pyaoscx.rest.v10_13` and `pyaoscx.rest.v10_16`, mirroring the existing `v10_09` definition (selectors, depths, OSPF-area defaults). This lets `Session` / `API.create()` accept `rest_version` 10.13 and 10.16 and reach resources introduced after 10.09.

## Testing
- `black --check` and `flake8` clean
- `API.create("10.13")` and `API.create("10.16")` resolve to the correct version
- Validated live against a 6300 (FL.10.17): client probe profiles and IPFIX / Traffic Insight resources reachable at the corresponding REST version

Fixes #118.